### PR TITLE
Исправление: роутер со слабым процессором не может корректно обновить vpn-подключения

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea/
 ipk/
 .env
+.vs/
 
 ## User-specific stuff
 #.idea/**/workspace.xml

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1334,6 +1334,7 @@ EOF
 	for inface_cli in ${inface_list}; do
 #		переподключаем текущее соединение
 		reset_connection "${inface_cli}"
+		sleep 10
 		# получаем описание интерфейса
 		description=$(get_value_interface_field "${inface_cli}" description | sed 's|\/|\\/|g')
 		# вставляем описание в файл /opt/etc/inface_equals


### PR DESCRIPTION
Я имею роутер Zyxel Keenetic Extra II где одноядерный процессор 2016 года. При выполнении `kvas setup` или `kvas vpn rescan` он почти всегда определяет vpn-подключения как отключенные/не работающие из-за чего настройка (выполнение `kvas setup`) невозможно. Это исправление к описанной выше проблеме.