### PR TITLE
Добавление интерфейса pptp

### DIFF
--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1683,7 +1683,7 @@ EOF
 	# очищаем файл с именами интерфейсов
 	echo "shadowsocks|$(get_ssr_entware_interface)|shadowsocks" > "${INFACE_NAMES_FILE}"
 	# обозначаем список типов обрабатываемых VPN интерфейсов
-	types_inface='"OpenVPN","Wireguard","IKE","SSTP","PPPOE","L2TP"'
+	types_inface='"OpenVPN","Wireguard","IKE","SSTP","PPPOE","L2TP","PPTP"'
 #	архивный вариант с выключенными интерфейсами сотовых операторов
 #	types_inface='"OpenVPN","Wireguard","IKE","SSTP","PPPOE","L2TP","CdcEthernet","UsbLte"'
 	# получаем список ID интерфейсов в наличии на роутере через пробел


### PR DESCRIPTION
У меня VPN подключется по протоколу [PPTP](https://help.keenetic.com/hc/ru/articles/360000619060-%D0%9A%D0%BB%D0%B8%D0%B5%D0%BD%D1%82-PPTP-%D0%B8-L2TP). КВАС о таком не знает и, соответственно, не юзабелен.
После добавления поддержки протокола всё завелось с полпинка.

PS. Нужно обновить [документацию](https://github.com/qzeleza/kvas/wiki/%D0%A3%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0-%D0%BF%D0%B0%D0%BA%D0%B5%D1%82%D0%B0#%D0%BF%D0%BE%D0%B4%D0%B3%D0%BE%D1%82%D0%BE%D0%B2%D0%B8%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D1%8B%D0%B5-%D0%B4%D0%B5%D0%B9%D1%81%D1%82%D0%B2%D0%B8%D1%8F), но я не нашёл, как сделать PR в вики.