### PR TITLE
Fix incorrect status display for WireGuard interfaces in cmd_bridge_vpn_access_list function

### DIFF
--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -812,7 +812,7 @@ cmd_bridge_vpn_access_list() {
 
 			printf '%s\n' "${interfaces_list}" |
 			while IFS= read -r desc_full ; do
-			if echo "${desc_full}" | grep -q Bridge ; then
+			if echo "${desc_full}" | grep -q Bridge || echo "${desc_full}" | grep -q Wireguard ; then
 				net_ip=$(echo "${desc_full}" | sed 's/.*\[\([0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\].*/\1/')
 				ent_inf=$(ip a | grep global | grep "${net_ip}" | sed 's/.* \(.*\)$/\1/')
 			else


### PR DESCRIPTION
This pull request addresses a bug in the `cmd_bridge_vpn_access_list` function where the status of WireGuard interfaces was incorrectly displayed. The issue was caused by an incorrect determination of the `ent_inf` variable for WireGuard interfaces.

### Changes made:
1. Added a check for the presence of WireGuard interfaces along with Bridge interfaces.
2. Corrected the logic to extract the interface name (`ent_inf`) for WireGuard interfaces using the correct parsing method.
3. Updated the `cmd_bridge_vpn_access_list` function to ensure accurate status reporting for all interface types, including WireGuard.

These changes ensure that the status of WireGuard interfaces is correctly displayed as either "Added" or "Not Added" based on their actual presence in the configuration file `/opt/etc/kvas.conf`.

### Testing:
- Verified that the status of various types of interfaces (Bridge, WireGuard, etc.) is correctly displayed in the output.
- Tested the updated function to ensure no regressions were introduced.