### PR TITLE
Исправлено дубрирование yt3.ggpht.com в закваске для YouTube

### DIFF
--- a/opt/etc/conf/tags.list
+++ b/opt/etc/conf/tags.list
@@ -74,7 +74,6 @@ yt3.ggpht.com
 *youtube.com
 i.ytimg.com
 youtubei.googleapis.com
-yt3.ggpht.com
 yt3.googleusercontent.com
 m.youtube.com
 *google.com


### PR DESCRIPTION
Исправил дублирование yt3.ggpht.com в закваске для YouTube.
Ссылка повторялась на 73 и 77 строках

Скриншот как было:
<img width="345" alt="image" src="https://github.com/user-attachments/assets/da932174-001a-44b7-a3c4-4e8cb4291cf1">
