### PR TITLE
Убраны дублирования в закваске для youtube

### DIFF
--- a/opt/etc/conf/tags.list
+++ b/opt/etc/conf/tags.list
@@ -85,11 +85,8 @@ www.youtube.com
 youtu.be
 *ggpht.com
 *ytimg.com
-play.google.com
 nhacmp3youtube.com
 *googleusercontent.com
-gstatic.com
-googleapis.com
 *l.google
 
 [docker]


### PR DESCRIPTION
Убраны дублирования googleapis.com, gstatic.com и play.google.com