### PR TITLE
Перехват DNS: цепочки, приоритет (доработка)

### DIFF
--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -230,7 +230,7 @@ cmd_debug_iptables() {
 	output=$(iptables-save | grep -F kvas_ipset)
 	echo_debug 'Роутинг подсетей' "${output}"
 
-	output=$(iptables-save | grep -F 53 | grep -Fv _NDM | grep -Fv :INPUT | grep -Fv :PREROUTING | grep -Fv :OUTPUT)
+	output=$(iptables-save | grep -F "${DNS_CHAIN}" | grep -Fv :"${DNS_CHAIN}")
 	echo_debug 'Роутинг DNS' "${output}"
 
 	output=$(iptables -L -t nat)

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -291,9 +291,12 @@ get_ikev2_net_pool() {
 #TODO: в ip4_firewall_dns_rules_set использовать вызов этой обёртки
 ip4_add_to_dns_routing() {
 	if [ -n "${1}" ]; then
-		local iptables_filter=' '$(echo "${1}" | tr -d ' ')
+		local iptables_filter=$(echo "${1}" | tr -d ' ')
+		local submessage=" по критерию ${iptables_filter}"
+		iptables_filter=" ${iptables_filter}"
 	else
 		local iptables_filter=''
+		local submessage=''
 	fi
 
 	local router_ip=$(get_router_ip)
@@ -301,6 +304,8 @@ ip4_add_to_dns_routing() {
 		if ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F "${router_ip}" | grep -Fq "${DNS_PORT}" ; then
 			continue
 		fi
+
+		log_warning "Подключение перенаправления ${protocol} в DNSMasq${submessage}"
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
 		iptables -A PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
@@ -725,9 +730,12 @@ ikev2_net_access_add() {
 #Example input param:-i sstp+
 ip4_delete_from_dns_routing() {
 	if [ -n "${1}" ]; then
-		local iptables_filter=' '$(echo "${1}" | tr -d ' ')
+		local iptables_filter=$(echo "${1}" | tr -d ' ')
+		local submessage=" по критерию ${iptables_filter}"
+		iptables_filter=" ${iptables_filter}"
 	else
 		local iptables_filter=''
+		local submessage=''
 	fi
 
 	local router_ip=$(get_router_ip)
@@ -735,6 +743,8 @@ ip4_delete_from_dns_routing() {
 		if ! ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F "${router_ip}" | grep -Fq "${DNS_PORT}" ; then
 			continue
 		fi
+
+		log_warning "Отключение перенаправления ${protocol} в DNSMasq${submessage}"
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
 		iptables -D PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -170,7 +170,7 @@ ip4_flush_cache(){
 # Подключаем правила для корректной работы DNS трафика через 53 порт
 # ------------------------------------------------------------------------------------------
 ip4_firewall_dns_rules_set() {
-	ip4_add_to_dns_routing '-i br0'
+	ip4__dns__add_routing '-i br0'
 }
 
 
@@ -312,7 +312,7 @@ ip4__dns__get_rulenum() {
 # Перенаправляем dns-запросы в dnsmasq
 #Example input param:-s 192.168.3.0/24 -i eth3
 #Example input param:-i sstp+
-ip4_add_to_dns_routing() {
+ip4__dns__add_routing() {
 	if [ -n "${1}" ]; then
 		local iptables_filter=$(echo "${1}" | xargs)
 		local submessage=" по критерию ${iptables_filter}"
@@ -363,7 +363,7 @@ ip4_add_selected_guest_to_vpn_network() {
 	iptables_filter="${iptables_filter}-i ${net_interface}"
 
 	log_warning "Подключаем правила гостевого трафика ${submessage}${net_pool}) для VPN."
-	ip4_add_to_dns_routing "${iptables_filter}"
+	ip4__dns__add_routing "${iptables_filter}"
 	if fastnet_enabled ; then
 		if ! iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${IPSET_TABLE_NAME}" | grep -Fq "${VPN_IPTABLES_CHAIN}" ; then
 			# без echo дублирование пробелов (что даёт warning и проблему наличия)
@@ -434,7 +434,7 @@ ip4_add_selected_guest_to_ssr_network() {
 
 	log_warning "Подключаем правила гостевого трафика ${submessage}${net_pool}) для ShadowSocks."
 
-	ip4_add_to_dns_routing "${iptables_filter}"
+	ip4__dns__add_routing "${iptables_filter}"
 
 	local ss_port=$(get_config_value SSR_DNS_PORT)
 	for protocol in tcp udp ; do
@@ -751,7 +751,7 @@ ikev2_net_access_add() {
 # Отключение перехвата dns-запросов в dnsmasq
 #Example input param:-s 192.168.3.0/24 -i eth3
 #Example input param:-i sstp+
-ip4_delete_from_dns_routing() {
+ip4__dns__delete_routing() {
 	if [ -n "${1}" ]; then
 		local iptables_filter=$(echo "${1}" | xargs)
 		local submessage=" по критерию ${iptables_filter}"
@@ -801,7 +801,7 @@ ip4_firewall_rm_vpn_selected_guest_net() {
 	iptables_filter="${iptables_filter}-i ${net_interface}"
 
 	log_warning "Отключаем правила гостевого трафика ${submessage}${net_pool}) для VPN."
-	ip4_delete_from_dns_routing "${iptables_filter}"
+	ip4__dns__delete_routing "${iptables_filter}"
 	if fastnet_enabled ; then
 		if iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${IPSET_TABLE_NAME}" | grep -Fq "${VPN_IPTABLES_CHAIN}" ; then
 			# без echo дублирование пробелов (что даёт warning и проблему наличия)
@@ -873,7 +873,7 @@ ip4_firewall_rm_ssr_selected_guest_net() {
 
 	log_warning "Отключаем правила гостевого трафика ${submessage}${net_pool}) для ShadowSocks."
 
-	ip4_delete_from_dns_routing "${iptables_filter}"
+	ip4__dns__delete_routing "${iptables_filter}"
 
 	local ss_port=$(get_config_value SSR_DNS_PORT)
 	for protocol in tcp udp ; do

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -170,7 +170,7 @@ ip4_flush_cache(){
 # Подключаем правила для корректной работы DNS трафика через 53 порт
 # ------------------------------------------------------------------------------------------
 ip4_firewall_dns_rules_set() {
-	ip4__dns__add_routing '-i br0'
+	ip4__dns__add_routing "-i $(get_local_inface)"
 }
 
 
@@ -223,7 +223,7 @@ ip4_firewall_vpn_mark(){
 		ip4tables ${VPN_IPTABLES_CHAIN} -t "${table}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM} &>/dev/nullcd
 		ip4tables ${VPN_IPTABLES_CHAIN} -t "${table}" -j CONNMARK --save-mark &>/dev/null
 
-		ip4tables PREROUTING -t "${table}" -i br0 -m set --match-set "${IPSET_TABLE_NAME}" dst -j "${VPN_IPTABLES_CHAIN}" &>/dev/null
+		ip4tables PREROUTING -t "${table}" -i "$(get_local_inface)" -m set --match-set "${IPSET_TABLE_NAME}" dst -j "${VPN_IPTABLES_CHAIN}" &>/dev/null
 
 		# ip4tables PREROUTING -t "${table}" -m set --match-set "${IPSET_TABLE_NAME}" dst -j ${VPN_IPTABLES_CHAIN} &>/dev/null
 		# ip4tables OUTPUT     -t "${table}" -m set --match-set "${IPSET_TABLE_NAME}" dst -j ${VPN_IPTABLES_CHAIN} &>/dev/null

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -284,16 +284,15 @@ ip4_add_to_dns_routing() {
 		local submessage=''
 	fi
 
-	local router_ip=$(get_router_ip)
 	for protocol in tcp udp ; do
-		if ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F "${router_ip}" | grep -Fq "${DNS_PORT}" ; then
+		if ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F '127.0.0.1' | grep -Fq "${DNS_PORT}" ; then
 			continue
 		fi
 
 		log_warning "Подключение перенаправления ${protocol} в DNSMasq${submessage}"
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -A PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
+		iptables -A PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
 	done
 }
 
@@ -723,16 +722,15 @@ ip4_delete_from_dns_routing() {
 		local submessage=''
 	fi
 
-	local router_ip=$(get_router_ip)
 	for protocol in tcp udp ; do
-		if ! ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F "${router_ip}" | grep -Fq "${DNS_PORT}" ; then
+		if ! ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F '127.0.0.1' | grep -Fq "${DNS_PORT}" ; then
 			continue
 		fi
 
 		log_warning "Отключение перенаправления ${protocol} в DNSMasq${submessage}"
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -D PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
+		iptables -D PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
 	done
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -291,7 +291,7 @@ get_ikev2_net_pool() {
 #TODO: в ip4_firewall_dns_rules_set использовать вызов этой обёртки
 ip4_add_to_dns_routing() {
 	if [ -n "${1}" ]; then
-		local iptables_filter=$(echo "${1}" | tr -d ' ')
+		local iptables_filter=' '$(echo "${1}" | tr -d ' ')
 	else
 		local iptables_filter=''
 	fi
@@ -303,7 +303,7 @@ ip4_add_to_dns_routing() {
 		fi
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -A PREROUTING -w -t nat $(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
+		iptables -A PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
 	done
 }
 
@@ -725,7 +725,7 @@ ikev2_net_access_add() {
 #Example input param:-i sstp+
 ip4_delete_from_dns_routing() {
 	if [ -n "${1}" ]; then
-		local iptables_filter=$(echo "${1}" | tr -d ' ')
+		local iptables_filter=' '$(echo "${1}" | tr -d ' ')
 	else
 		local iptables_filter=''
 	fi
@@ -737,7 +737,7 @@ ip4_delete_from_dns_routing() {
 		fi
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -D PREROUTING -w -t nat $(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
+		iptables -D PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination "${router_ip}":"${DNS_PORT}"
 	done
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -271,6 +271,44 @@ get_ikev2_net_pool() {
 	echo "${pool_start}" | sed 's/\.[0-9]\{1,3\}$/.0\/24/'
 }
 
+# Возвращает номер (в nat PREROUTING) по куску правила
+#Example input param: NDM_UPNP_REDIRECT_SYS
+ip4__get_rulenum() {
+	if [ -z "${1}" ]; then
+		error "[${FUNCNAME}] Не передан обязательный параметр — правило для поиска"
+		return
+	fi
+	local find="${1}"
+
+	# если потребуются другие таблицы или цепочки, можно сделать их входящими параметрами
+	local table='nat'
+	local chain='PREROUTING'
+
+	echo $(iptables-save -t "${table}" | grep -F "${chain}" | grep -vF :"${chain}" \
+	 | grep -nF -- "${find}" | head -n 1 | grep -oE '^[0-9]+')
+}
+
+# Возвращает номер (в nat PREROUTING) для DNS-правил
+ip4__dns__get_rulenum() {
+	# вместо NDM_DNS_REDIRECT
+	local rulenum=$(ip4__get_rulenum 'NDM_DNS_REDIRECT')
+	if [ -n "${rulenum}" ]; then
+		echo "${rulenum}"
+		return
+	fi
+
+	# после NDM_DNAT
+	local rulenum=$(ip4__get_rulenum 'NDM_DNAT')
+	if [ -n "${rulenum}" ]; then
+		echo $((rulenum + 1))
+		return
+	fi
+
+	# высший приоритет
+	# если DNS перехват не будет работать, удаляем вышестоящее
+	echo '1'
+}
+
 # Перенаправляем dns-запросы в dnsmasq
 #Example input param:-s 192.168.3.0/24 -i eth3
 #Example input param:-i sstp+
@@ -284,6 +322,7 @@ ip4_add_to_dns_routing() {
 		local submessage=''
 	fi
 
+	local rulenum=$(ip4__dns__get_rulenum)
 	for protocol in tcp udp ; do
 		if ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F '127.0.0.1' | grep -Fq "${DNS_PORT}" ; then
 			continue
@@ -292,7 +331,7 @@ ip4_add_to_dns_routing() {
 		log_warning "Подключение перенаправления ${protocol} в DNSMasq${submessage}"
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -A PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
+		iptables -I PREROUTING "${rulenum}" -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
 	done
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -170,21 +170,7 @@ ip4_flush_cache(){
 # Подключаем правила для корректной работы DNS трафика через 53 порт
 # ------------------------------------------------------------------------------------------
 ip4_firewall_dns_rules_set() {
-	local router_ip=$(get_router_ip)
-	local submessage=" DNS трафика домашней сети в ${router_ip}:${DNS_PORT}."
-
-	log_warning "Подключаем перенаправление${submessage}"
-	for protocol in tcp udp ; do
-		local iptables_rule=" -i br0 -p ${protocol} -m ${protocol} --dport 53 -j DNAT --to-destination ${router_ip}:${DNS_PORT}"
-
-		if ip4save | grep -Fq -- "${iptables_rule}" ; then
-			continue
-		fi
-
-		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -A PREROUTING -t nat$(echo "${iptables_rule}") &>/dev/null \
-		 || echo "[${FUNCNAME}] Возникла ошибка при подключении перенаправления ${protocol}${submessage}"
-	done
+	ip4_add_to_dns_routing '-i br0'
 }
 
 
@@ -288,7 +274,6 @@ get_ikev2_net_pool() {
 # Перенаправляем dns-запросы в dnsmasq
 #Example input param:-s 192.168.3.0/24 -i eth3
 #Example input param:-i sstp+
-#TODO: в ip4_firewall_dns_rules_set использовать вызов этой обёртки
 ip4_add_to_dns_routing() {
 	if [ -n "${1}" ]; then
 		local iptables_filter=$(echo "${1}" | tr -d ' ')

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -276,7 +276,7 @@ get_ikev2_net_pool() {
 #Example input param:-i sstp+
 ip4_add_to_dns_routing() {
 	if [ -n "${1}" ]; then
-		local iptables_filter=$(echo "${1}" | tr -d ' ')
+		local iptables_filter=$(echo "${1}" | xargs)
 		local submessage=" по критерию ${iptables_filter}"
 		iptables_filter=" ${iptables_filter}"
 	else
@@ -714,7 +714,7 @@ ikev2_net_access_add() {
 #Example input param:-i sstp+
 ip4_delete_from_dns_routing() {
 	if [ -n "${1}" ]; then
-		local iptables_filter=$(echo "${1}" | tr -d ' ')
+		local iptables_filter=$(echo "${1}" | xargs)
 		local submessage=" по критерию ${iptables_filter}"
 		iptables_filter=" ${iptables_filter}"
 	else

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -277,7 +277,7 @@ ip4__dns__create_chain() {
 		return
 	fi
 
-	log_warning 'Создание цепочки для перенаправления в DNSMasq'
+	log_warning 'Создание цепочки для DNS перенаправления'
 
 	iptables -N "${DNS_CHAIN}" -w -t nat
 	for protocol in udp tcp ; do
@@ -336,19 +336,16 @@ ip4__dns__add_routing() {
 		local submessage=''
 	fi
 
+	if iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -Fq "${DNS_CHAIN}" ; then
+		return
+	fi
 	local rulenum=$(ip4__dns__get_rulenum)
-	for protocol in tcp udp ; do
-		if ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F '127.0.0.1' | grep -Fq "${DNS_PORT}" ; then
-			continue
-		fi
 
-		log_warning "Подключение перенаправления ${protocol} в DNSMasq${submessage}"
+	log_warning "Подключение DNS перенаправления с приоритетом ${rulenum}${submessage}"
 
-		ip4__dns__create_chain
-
-		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -I PREROUTING "${rulenum}" -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
-	done
+	ip4__dns__create_chain
+	# без echo дублирование пробелов (что даёт warning и проблему наличия)
+	iptables -I PREROUTING "${rulenum}" -w -t nat$(echo "${iptables_filter}") -j "${DNS_CHAIN}"
 }
 
 ip4_add_selected_guest_to_vpn_network() {
@@ -777,16 +774,14 @@ ip4__dns__delete_routing() {
 		local submessage=''
 	fi
 
-	for protocol in tcp udp ; do
-		if ! ip4save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -F "${protocol}" | grep -F 53 | grep -F 'DNAT' | grep -F '127.0.0.1' | grep -Fq "${DNS_PORT}" ; then
-			continue
-		fi
+	if ! iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -Fq "${DNS_CHAIN}" ; then
+		return
+	fi
 
-		log_warning "Отключение перенаправления ${protocol} в DNSMasq${submessage}"
+	log_warning "Отключение DNS перенаправления${submessage}"
 
-		# без echo дублирование пробелов (что даёт warning и проблему наличия)
-		iptables -D PREROUTING -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
-	done
+	# без echo дублирование пробелов (что даёт warning и проблему наличия)
+	iptables -D PREROUTING -w -t nat$(echo "${iptables_filter}") -j "${DNS_CHAIN}"
 }
 
 ip4_firewall_rm_vpn_selected_guest_net() {

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -54,7 +54,7 @@ get_model() {
 		local version_data=$(ndmc -c show version)
 	fi
 
-	echo "${version_data}" | grep -F 'model' | head -1 | cut -d: -f2 | tr -d ' '
+	echo "${version_data}" | grep -F 'model' | head -1 | cut -d: -f2 | xargs
 }
 
 get_version() {

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -28,7 +28,7 @@ DNS_PORT=9753
 
 
 
-
+DNS_CHAIN=KVAS_DNS
 # Метка VPN цепочки для правил iptables
 VPN_IPTABLES_CHAIN=VPNREDIR
 # Метка SHADOWSOCKS цепочки для правил iptables
@@ -271,6 +271,20 @@ get_ikev2_net_pool() {
 	echo "${pool_start}" | sed 's/\.[0-9]\{1,3\}$/.0\/24/'
 }
 
+# Создаёт (если нет) цепочку в nat для DNS редиректа
+ip4__dns__create_chain() {
+	if iptables-save | grep -Fq "${DNS_CHAIN}"; then
+		return
+	fi
+
+	log_warning 'Создание цепочки для перенаправления в DNSMasq'
+
+	iptables -N "${DNS_CHAIN}" -w -t nat
+	for protocol in udp tcp ; do
+		iptables -A "${DNS_CHAIN}" -w -t nat -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
+	done
+}
+
 # Возвращает номер (в nat PREROUTING) по куску правила
 #Example input param: NDM_UPNP_REDIRECT_SYS
 ip4__get_rulenum() {
@@ -329,6 +343,8 @@ ip4__dns__add_routing() {
 		fi
 
 		log_warning "Подключение перенаправления ${protocol} в DNSMasq${submessage}"
+
+		ip4__dns__create_chain
 
 		# без echo дублирование пробелов (что даёт warning и проблему наличия)
 		iptables -I PREROUTING "${rulenum}" -w -t nat$(echo "${iptables_filter}") -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -284,13 +284,17 @@ get_ikev2_net_pool() {
 	pool_start=$(echo "${ikev2_settings}" | grep pool-start | cut -d':' -f2 | sed 's/[\,\" ]//g;')
 	echo "${pool_start}" | sed 's/\.[0-9]\{1,3\}$/.0\/24/'
 }
- 
+
 # Перенаправляем dns-запросы в dnsmasq
 #Example input param:-s 192.168.3.0/24 -i eth3
 #Example input param:-i sstp+
 #TODO: в ip4_firewall_dns_rules_set использовать вызов этой обёртки
 ip4_add_to_dns_routing() {
-	local iptables_filter="${1}"
+	if [ -n "${1}" ]; then
+		local iptables_filter=$(echo "${1}" | tr -d ' ')
+	else
+		local iptables_filter=''
+	fi
 
 	local router_ip=$(get_router_ip)
 	for protocol in tcp udp ; do
@@ -720,7 +724,11 @@ ikev2_net_access_add() {
 #Example input param:-s 192.168.3.0/24 -i eth3
 #Example input param:-i sstp+
 ip4_delete_from_dns_routing() {
-	local iptables_filter="${1}"
+	if [ -n "${1}" ]; then
+		local iptables_filter=$(echo "${1}" | tr -d ' ')
+	else
+		local iptables_filter=''
+	fi
 
 	local router_ip=$(get_router_ip)
 	for protocol in tcp udp ; do


### PR DESCRIPTION
_Изменено: добавлена обёртка как в SS, обсуждение в #217. Т.к. имя ветки оставлено тем же самым, то может потребоваться удаление её локальной копии_

Вероятное решение https://github.com/qzeleza/kvas/issues/213

Вставка станет идти между NDM_DNAT и NDM_DNS_REDIRECT. Если у кого-то не будет работать, то правка одной строчки — и правила выше NDM_DNAT. Сейчас до конца не понятно, какая из системных цепочек мешает выполнению редиректа КВАСом.