### PR TITLE
Debug: доработка новых команд

### DIFF
--- a/opt/bin/kvas
+++ b/opt/bin/kvas
@@ -123,8 +123,8 @@ case "${1}" in
 	dns)
 		case "${2}" in
 			debug)           cmd_debug_dns                      ;;
-			server | remote) dns_server_install_remotely "${3}" ;;
 			test)            cmd_dns_test "${3}"                ;;
+			server | remote) dns_server_install_remotely "${3}" ;;
 			*)               cmd_dnsmasq_dns_change "${2}"      ;;
 		esac
 		;;

--- a/opt/bin/kvas
+++ b/opt/bin/kvas
@@ -181,7 +181,7 @@ case "${1}" in
 			clear | flush) cmd_ipset_flush      ;;
 			refill)        cmd_ipset_refill     ;;
 			add)           cmd_ipset_add "${3}" ;;
-			*)             cmd_ipset            ;;
+			*)             cmd_ipset "${2}"     ;;
 		esac
 		;;
 

--- a/opt/bin/kvas
+++ b/opt/bin/kvas
@@ -122,6 +122,7 @@ case "${1}" in
 
 	dns)
 		case "${2}" in
+			debug) cmd_debug_dns ;;
 			server) 		dns_server_install_remotely "${3}" ;;
 			test) 			cmd_dns_test "${3}";;
 			*) 				cmd_dnsmasq_dns_change "${2}" ;;

--- a/opt/bin/kvas
+++ b/opt/bin/kvas
@@ -122,10 +122,10 @@ case "${1}" in
 
 	dns)
 		case "${2}" in
-			debug) cmd_debug_dns ;;
-			server | remote) 		dns_server_install_remotely "${3}" ;;
-			test) 			cmd_dns_test "${3}";;
-			*) 				cmd_dnsmasq_dns_change "${2}" ;;
+			debug)           cmd_debug_dns                      ;;
+			server | remote) dns_server_install_remotely "${3}" ;;
+			test)            cmd_dns_test "${3}"                ;;
+			*)               cmd_dnsmasq_dns_change "${2}"      ;;
 		esac
 		;;
 

--- a/opt/bin/kvas
+++ b/opt/bin/kvas
@@ -123,7 +123,7 @@ case "${1}" in
 	dns)
 		case "${2}" in
 			debug) cmd_debug_dns ;;
-			server) 		dns_server_install_remotely "${3}" ;;
+			server | remote) 		dns_server_install_remotely "${3}" ;;
 			test) 			cmd_dns_test "${3}";;
 			*) 				cmd_dnsmasq_dns_change "${2}" ;;
 		esac

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -235,7 +235,6 @@ cmd_debug_iptables() {
 	ready 'Версия ndw4'       && when_ok "$(version_os)"
 	ready 'Внешний интерфейс' && when_ok "$(get_external_interface)"
 	ready 'IKEv2 интерфейс'   && when_ok "$(get_entware_ikev2_inface)"
-	ready 'IKEv2 IP'          && when_ok "$(get_ikev2_net_pool)"
 	echo
 
 	echo_debug 'Маршруты (подключитесь к гостевой заранее)' "${output}"

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -405,6 +405,16 @@ cmd_ipset_refill() {
 }
 
 cmd_ipset() {
+	if [ -n "${1}" ]; then
+		if ! echo "${1}" | grep -qE "^${IP_FILTER}$"; then
+			error "Параметр ${1} не известен."
+
+			echo 'Можете передать любой IP для проверки его наличия в списке для попадания в тоннель,'
+			echo 'или вызвать команду без этого параметра.'
+			return 1
+		fi
+	fi
+
 	local output=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF ':' | wc -l)
 	ready 'Количество записей' && when_ok "${output}"
 
@@ -422,18 +432,27 @@ cmd_ipset() {
 	fi
 	ready 'ifconfig.me' && when_ok "${output}"
 
+	if [ -n "${1}" ]; then
+		if ipset list "${IPSET_TABLE_NAME}" | grep -qF "${1}"; then
+			output='есть'
+		else
+			output='нет'
+		fi
+		ready "${1}" && when_ok "${output}"
+	fi
+
 	echo
 
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -eq 0 ]; then
 		output='Или не приходило ещё ни одного DNS-запроса о доменах из kvas list;\nили ошибки в конфигурации DNS'
-		if [ -z "${1}" ] ; then
+		if [ -z "${2}" ] ; then
 			# если вызывается как один из дебагов, то можно передать silent/short
 			output="${output}, вызовите kvas debug dns"
 		fi
 		output="${output}"';\nили проблема с перехватом DNS'
-		if [ -z "${1}" ] ; then
+		if [ -z "${2}" ] ; then
 			# если вызывается как один из дебагов, то можно передать silent/short
 			output="${output}, вызовите kvas debug iptables"
 		fi
@@ -454,7 +473,7 @@ cmd_ipset() {
 	if [ "$count" -eq 0 ]; then
 		if grep -Eq -- "${IP_FILTER}" "${KVAS_LIST_FILE}"; then
 			output='Или нет корректных IP, диапазонов в kvas list;\nили проблема с их переносом'
-			if [ -z "${1}" ] ; then
+			if [ -z "${2}" ] ; then
 				# если вызывается как один из дебагов, то можно передать silent/short
 				output="${output}, вызовите kvas ipset clear"
 			fi

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -327,7 +327,7 @@ get_netstat() {
 
 cmd_debug_dnsmasq() {
 	if ! dnsmasq__is_working ; then
-		echo 'Дальнейшая проверка остановлена.'
+		echo 'Дальнейшая проверка DNSMasq остановлена.'
 		return
 	fi
 
@@ -378,17 +378,16 @@ cmd_debug_dnsmasq() {
 }
 
 cmd_debug_dns() {
-	# если вызывается как один из дебагов, то можно передать silent/short
-	if [ -z "${1}" ] ; then
-		echo 'Перехваты DNS можно проверить командой kvas debug iptables'
-		echo 'Список IP для тоннеля можно посмотреть командой kvas ipset'
-		echo
-	fi
-
 	if [ -f "${ADGUARDHOME_DEMON}" ] && "${ADGUARDHOME_DEMON}" status | grep -Fq 'alive' ; then
 		cmd_debug_adguard
 	else
 		cmd_debug_dnsmasq
+	fi
+
+	# если вызывается как один из дебагов, то можно передать silent/short
+	if [ -z "${1}" ] ; then
+		echo 'Перехваты DNS можно проверить командой kvas debug iptables'
+		echo 'Список IP для тоннеля можно посмотреть командой kvas ipset'
 	fi
 }
 

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -384,6 +384,7 @@ cmd_debug_dns() {
 		cmd_debug_dnsmasq
 	fi
 
+	ready 'NDNProxy версия' && when_ok "$(ndnproxy 2>&1 | grep -Eo 'ndnproxy [0-9\.]+' | head -n 1 | cut -d ' ' -f2)"
 	echo_debug 'Комплектный DNS роутера (базово) слушает:' "$(get_netstat 'ndnproxy')"
 
 	# если вызывается как один из дебагов, то можно передать silent/short

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -245,13 +245,23 @@ cmd_debug_iptables() {
 		output=$(iptables__get_by_chain "${CHAIN_MARK_TO_TABLE}")
 	fi
 	if [ -z "${output}" ] ; then
-		output='Правила не найдены!\nСообщите об этом https://t.me/kvas_pro и вызовите kvas reset'
+		output='Правила не найдены!'
+
+		# если вызывается как один из дебагов, то можно передать silent/short
+		if [ -z "${1}" ] ; then
+			output="${output}"'\nСообщите об этом https://t.me/kvas_pro и вызовите kvas reset'
+		fi
 	fi
 	echo_debug 'Роутинг подсетей' "${output}"
 
 	output=$(iptables__get_by_chain "${CHAIN_DNS}")
 	if [ -z "${output}" ] ; then
-		output='Правила не найдены!\nСообщите об этом https://t.me/kvas_pro и вызовите kvas reset'
+		output='Правила не найдены!'
+
+		# если вызывается как один из дебагов, то можно передать silent/short
+		if [ -z "${1}" ] ; then
+			output="${output}"'\nСообщите об этом https://t.me/kvas_pro и вызовите kvas reset'
+		fi
 	fi
 	echo_debug 'Роутинг DNS' "${output}"
 
@@ -263,9 +273,9 @@ cmd_debug_iptables() {
 }
 
 cmd_debug_dns() {
-	# если вызывается как один из дебагов, то можно передать silent
+	# если вызывается как один из дебагов, то можно передать silent/short
 	if [ -z "${1}" ] ; then
-		echo 'Для просмотра перехватов DNS вызовите kvas debug iptables'
+		echo 'Для проверки перехватов DNS вызовите kvas debug iptables'
 		echo
 	fi
 

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -276,19 +276,7 @@ cmd_debug_adguard() {
 	echo 'Полная поддержка AdGuardHome будет возвращена в скором времени.'
 }
 
-cmd_debug_dns() {
-	# если вызывается как один из дебагов, то можно передать silent/short
-	if [ -z "${1}" ] ; then
-		echo 'Перехваты DNS можно проверить командой kvas debug iptables'
-		echo 'Список IP для тоннеля можно посмотреть командой kvas ipset'
-		echo
-	fi
-
-	if [ -f "${ADGUARDHOME_DEMON}" ] && "${ADGUARDHOME_DEMON}" status | grep -Fq 'alive' ; then
-		cmd_debug_adguard
-		return
-	fi
-
+cmd_debug_dnsmasq() {
 	if ! [ -f "${DNSMASQ_CONFIG}" ]; then
 		echo "Не найдена конфигурация DNSMasq ${DNSMASQ_CONFIG}"
 		echo 'Дальнейшая проверка остановлена.'
@@ -337,6 +325,21 @@ cmd_debug_dns() {
 
 	ready 'DNSCrypt версия' && when_ok "$(dnscrypt-proxy -version)"
 	echo_debug 'DNSCrypt слушает:' "$(netstat -tulpn | grep -F 'dnscrypt')"
+}
+
+cmd_debug_dns() {
+	# если вызывается как один из дебагов, то можно передать silent/short
+	if [ -z "${1}" ] ; then
+		echo 'Перехваты DNS можно проверить командой kvas debug iptables'
+		echo 'Список IP для тоннеля можно посмотреть командой kvas ipset'
+		echo
+	fi
+
+	if [ -f "${ADGUARDHOME_DEMON}" ] && "${ADGUARDHOME_DEMON}" status | grep -Fq 'alive' ; then
+		cmd_debug_adguard
+	else
+		cmd_debug_dnsmasq
+	fi
 }
 
 cmd_ipset_flush() {

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -272,6 +272,10 @@ cmd_debug_iptables() {
 	echo_debug 'PREROUTING nat' "${output}"
 }
 
+cmd_debug_adguard() {
+	echo 'Полная поддержка AdGuardHome будет возвращена в скором времени.'
+}
+
 cmd_debug_dns() {
 	# если вызывается как один из дебагов, то можно передать silent/short
 	if [ -z "${1}" ] ; then
@@ -280,11 +284,9 @@ cmd_debug_dns() {
 		echo
 	fi
 
-	if [ -f "${ADGUARDHOME_DEMON}" ] ; then
-		if "${ADGUARDHOME_DEMON}" status | grep -Fq 'alive' ; then
-			echo 'Полная поддержка AdGuardHome будет возвращена в скором времени.'
-			return
-		fi
+	if [ -f "${ADGUARDHOME_DEMON}" ] && "${ADGUARDHOME_DEMON}" status | grep -Fq 'alive' ; then
+		cmd_debug_adguard
+		return
 	fi
 
 	if ! [ -f "${DNSMASQ_CONFIG}" ]; then

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -277,13 +277,23 @@ cmd_debug_adguard() {
 }
 
 cmd_debug_dnsmasq() {
-	if ! [ -f "${DNSMASQ_CONFIG}" ]; then
+	if ! [ -f "${DNSMASQ_CONFIG}" ] ; then
 		error "Не найдена конфигурация DNSMasq ${DNSMASQ_CONFIG}"
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi
 	if ! command -v dnsmasq 2>&1 >/dev/null ; then
 		error 'Не найдена команда dnsmasq'
+		echo 'Дальнейшая проверка остановлена.'
+		return
+	fi
+	if ! [ -f "${DNSMASQ_DEMON}" ] ; then
+		error "Не найден файл запуска DNSMasq ${DNSMASQ_DEMON}"
+		echo 'Дальнейшая проверка остановлена.'
+		return
+	fi
+	if ! "${DNSMASQ_DEMON}" status | grep -Fq 'alive' ; then
+		error 'Не запущен DNSMasq'
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -404,7 +404,7 @@ cmd_ipset() {
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -eq 0 ]; then
-		echo_debug 'Для доменов 0' 'Или нет доменов в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
+		echo_debug 'Для доменов 0' 'Или нет корректных доменов в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
 	else
 		# геморрой из-за неподдержки -k в sort
 		output=''
@@ -418,7 +418,13 @@ cmd_ipset() {
 
 	count=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | wc -l)
 	if [ "$count" -eq 0 ]; then
-		echo_debug 'IP 0' 'Или нет IP или диапазонов в kvas list;\nили проблема с их переносом, вызовите kvas ipset clear.'
+		if grep -Eq -- "${IP_FILTER}" "${KVAS_LIST_FILE}"; then
+			output='Или нет корректных IP или диапазонов в kvas list;\nили проблема с их переносом, вызовите kvas ipset clear.'
+		else
+			output='Не используются IP или диапазоны в kvas list.'
+		fi
+
+		echo_debug 'IP 0' "${output}"
 	else
 		output=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | head -n 15 | cut -d' ' -f1)
 		echo_debug "IP ${count}, произвольные 15:" "${output}"

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -279,6 +279,13 @@ cmd_debug_dns() {
 		echo
 	fi
 
+	if [ -f "${ADGUARDHOME_DEMON}" ] ; then
+		if "${ADGUARDHOME_DEMON}" status | grep -Fq 'alive' ; then
+			echo 'Полная поддержка AdGuardHome будет возвращена в скором времени.'
+			return
+		fi
+	fi
+
 	if grep -q '^filter-rr=HTTPS' "${DNSMASQ_CONFIG}" ; then
 		local output='Отключен'
 	else

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -404,7 +404,7 @@ cmd_ipset() {
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -eq 0 ]; then
-		echo_debug 'Для доменов 0' 'Или нет ни одного домена в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
+		echo_debug 'Для доменов 0' 'Или нет доменов в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
 	else
 		# геморрой из-за неподдержки -k в sort
 		output=''
@@ -417,7 +417,9 @@ cmd_ipset() {
 	fi
 
 	count=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | wc -l)
-	if [ "$count" -gt 0 ]; then
+	if [ "$count" -eq 0 ]; then
+		echo_debug 'IP 0' 'Или нет IP или диапазонов в kvas list;\nили проблема с их переносом, вызовите kvas ipset clear.'
+	else
 		output=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | head -n 15 | cut -d' ' -f1)
 		echo_debug "IP ${count}, произвольные 15:" "${output}"
 	fi

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -277,6 +277,7 @@ cmd_debug_adguard() {
 }
 
 dnsmasq__is_working() {
+	# DNSMasq
 	if ! [ -f "${DNSMASQ_CONFIG}" ] ; then
 		error "Не найден файл настроек ${DNSMASQ_CONFIG}"
 	elif ! [ -f "${DNSMASQ_IPSET_HOSTS}" ] ; then
@@ -284,11 +285,24 @@ dnsmasq__is_working() {
 	elif ! command -v dnsmasq 2>&1 >/dev/null ; then
 		error 'Не найдена команда dnsmasq'
 	elif ! dnsmasq --test 2>&1 | grep -Fq 'check OK' ; then
-		error "Ошибки в файлах конфигурации ${DNSMASQ_CONFIG} или ${DNSMASQ_IPSET_HOSTS}"
+		error "Ошибка в файлах конфигурации ${DNSMASQ_CONFIG} или ${DNSMASQ_IPSET_HOSTS}"
 	elif ! [ -f "${DNSMASQ_DEMON}" ] ; then
 		error "Не найден файл запуска ${DNSMASQ_DEMON}"
 	elif ! "${DNSMASQ_DEMON}" status | grep -Fq 'alive' ; then
 		error 'Не запущен DNSMasq'
+
+	# DNSCrypt
+	elif ! [ -f "${DNSCRYPT_CONFIG}" ] ; then
+		error "Не найден файл настроек ${DNSCRYPT_CONFIG}"
+	elif ! command -v dnscrypt-proxy 2>&1 >/dev/null ; then
+		error 'Не найдена команда dnscrypt-proxy'
+	elif ! dnscrypt-proxy -config "${DNSCRYPT_CONFIG}" -check 2>&1 | grep -Fq 'successfully checked' ; then
+		error "Ошибка в файле конфигурации ${DNSCRYPT_CONFIG}"
+	elif ! [ -f "${DNSCRYPT_DEMON}" ] ; then
+		error "Не найден файл запуска ${DNSCRYPT_DEMON}"
+	elif ! "${DNSCRYPT_DEMON}" status | grep -Fq 'alive' ; then
+		error 'Не запущен DNSCrypt'
+
 	else
 		true
 		return

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -311,6 +311,20 @@ dnsmasq__is_working() {
 	false
 }
 
+get_netstat() {
+	if [ -z "${1}" ] ; then
+		error "[${FUNCNAME}] Не задан обязательный аргумент — фильтр"
+		return
+	fi
+	local filter="${1}"
+
+	local output=$(netstat -tulpn | grep -F -- "${filter}")
+	if [ -z "${output}" ] ; then
+		output="Сетевые соединения для ${filter} не найдены."
+	fi
+	echo "${output}"
+}
+
 cmd_debug_dnsmasq() {
 	if ! dnsmasq__is_working ; then
 		echo 'Дальнейшая проверка остановлена.'
@@ -329,7 +343,7 @@ cmd_debug_dnsmasq() {
 	ready 'DNSMasq версия' && when_ok "$(echo "${cached}" | grep -Eo 'version [0-9\.]+' | head -n 1 | cut -d ' ' -f2)"
 	#echo_debug 'DNSMasq модули:' "$(echo "${cached}" | grep -F 'options:' | head -n 1 | cut -d ':' -f2 | xargs | grep -o '[^ ]*')"
 
-	echo_debug 'DNSMasq слушает:' "$(netstat -tulpn | grep -F 'dnsmasq')"
+	echo_debug 'DNSMasq слушает:' "$(get_netstat 'dnsmasq')"
 
 
 	ready 'Сайтов для сбора IP' && when_ok "$(grep /${IPSET_TABLE_NAME} ${DNSMASQ_IPSET_HOSTS} | wc -l)"
@@ -360,7 +374,7 @@ cmd_debug_dnsmasq() {
 	fi
 
 	ready 'DNSCrypt версия' && when_ok "$(dnscrypt-proxy -version)"
-	echo_debug 'DNSCrypt слушает:' "$(netstat -tulpn | grep -F 'dnscrypt')"
+	echo_debug 'DNSCrypt слушает:' "$(get_netstat 'dnscrypt')"
 }
 
 cmd_debug_dns() {

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -403,7 +403,9 @@ cmd_ipset() {
 
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
-	if [ "$count" -gt 0 ]; then
+	if [ "$count" -eq 0 ]; then
+		echo_debug 'Для доменов 0' 'Или нет ни одного домена в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
+	else
 		# геморрой из-за неподдержки -k в sort
 		output=''
 		for ttl in $(echo "${cached}" | cut -d' ' -f3 | sort -n -r -u | head -n 7); do

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -419,7 +419,7 @@ cmd_ipset() {
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -eq 0 ]; then
-		output='Или нет корректных доменов в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
+		output='Или не приходило ещё ни одного DNS-запроса о доменах из kvas list;\nили ошибки в конфигурации DNS, вызовите kvas debug dns;\nили проблема с перехватом DNS, вызовите kvas debug iptables.'
 	else
 		# геморрой из-за неподдержки -k в sort
 		output=''

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -402,7 +402,7 @@ cmd_ipset() {
 	echo
 
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
-	local count=$(echo "${cached}" | wc -l)
+	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -gt 0 ]; then
 		# геморрой из-за неподдержки -k в sort
 		output=''

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -384,6 +384,8 @@ cmd_debug_dns() {
 		cmd_debug_dnsmasq
 	fi
 
+	echo_debug 'Комплектный DNS роутера слушает:' "$(get_netstat 'ndnproxy')"
+
 	# если вызывается как один из дебагов, то можно передать silent/short
 	if [ -z "${1}" ] ; then
 		echo 'Перехваты DNS можно проверить командой kvas debug iptables'

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -230,12 +230,12 @@ iptables__get_by_chain() {
 cmd_debug_iptables() {
 	local output=$(ip route)
 
-	ready 'Модель роутера' && when_ok "$(get_model)"
-	ready 'Версия ndw' && when_ok "$(get_version)"
-	ready 'Версия ndw4' && when_ok "$(version_os)"
+	ready 'Модель роутера'    && when_ok "$(get_model)"
+	ready 'Версия ndw'        && when_ok "$(get_version)"
+	ready 'Версия ndw4'       && when_ok "$(version_os)"
 	ready 'Внешний интерфейс' && when_ok "$(get_external_interface)"
-	ready 'IKEv2 интерфейс' && when_ok "$(get_entware_ikev2_inface)"
-	ready 'IKEv2 IP' && when_ok "$(get_ikev2_net_pool)"
+	ready 'IKEv2 интерфейс'   && when_ok "$(get_entware_ikev2_inface)"
+	ready 'IKEv2 IP'          && when_ok "$(get_ikev2_net_pool)"
 	echo
 
 	echo_debug 'Маршруты (подключитесь к гостевой заранее)' "${output}"

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -318,7 +318,7 @@ get_netstat() {
 	fi
 	local filter="${1}"
 
-	local output=$(netstat -tulpn | grep -F -- "${filter}")
+	local output=$(netstat -tulpn | grep -F -- "${filter}" | grep -v -- ':[0-9][0-9][0-9][0-9][0-9]')
 	if [ -z "${output}" ] ; then
 		output="Сетевые соединения для ${filter} не найдены."
 	fi
@@ -384,7 +384,7 @@ cmd_debug_dns() {
 		cmd_debug_dnsmasq
 	fi
 
-	echo_debug 'Комплектный DNS роутера слушает:' "$(get_netstat 'ndnproxy')"
+	echo_debug 'Комплектный DNS роутера (базово) слушает:' "$(get_netstat 'ndnproxy')"
 
 	# если вызывается как один из дебагов, то можно передать silent/short
 	if [ -z "${1}" ] ; then

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -286,6 +286,12 @@ cmd_debug_dns() {
 		fi
 	fi
 
+	if ! [ -f "${DNSMASQ_CONFIG}" ]; then
+		echo "Не найдена конфигурация DNSMasq ${DNSMASQ_CONFIG}"
+		echo 'Дальнейшая проверка остановлена.'
+		return
+	fi
+
 	if grep -q '^filter-rr=HTTPS' "${DNSMASQ_CONFIG}" ; then
 		local output='Отключен'
 	else
@@ -295,10 +301,10 @@ cmd_debug_dns() {
 
 	local cached=$(dnsmasq -v)
 
-	ready 'DNSMasq версия' && when_ok "$(echo "${cached}" | grep -Eo 'version [0-9\.]+' | head -1 | cut -d ' ' -f2)"
+	ready 'DNSMasq версия' && when_ok "$(echo "${cached}" | grep -Eo 'version [0-9\.]+' | head -n 1 | cut -d ' ' -f2)"
 	echo_debug 'DNSMasq слушает:' "$(netstat -tulpn | grep -F 'dnsmasq')"
 
-	#echo_debug 'DNSMasq модули:' "$(echo "${cached}" | grep -F 'options:' | head -1 | cut -d ':' -f2 | xargs | grep -o '[^ ]*')"
+	#echo_debug 'DNSMasq модули:' "$(echo "${cached}" | grep -F 'options:' | head -n 1 | cut -d ':' -f2 | xargs | grep -o '[^ ]*')"
 
 	ready 'Сайтов для сбора IP' && when_ok "$(grep /${IPSET_TABLE_NAME} ${DNSMASQ_IPSET_HOSTS} | wc -l)"
 

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -273,12 +273,17 @@ cmd_debug_iptables() {
 }
 
 cmd_debug_adguard() {
-	echo 'Полная поддержка AdGuardHome будет возвращена в скором времени.'
+	echo 'Полная поддержка AdGuardHome будет доделана в скором времени.'
 }
 
 cmd_debug_dnsmasq() {
 	if ! [ -f "${DNSMASQ_CONFIG}" ] ; then
-		error "Не найдена конфигурация DNSMasq ${DNSMASQ_CONFIG}"
+		error "Не найден файл настроек ${DNSMASQ_CONFIG}"
+		echo 'Дальнейшая проверка остановлена.'
+		return
+	fi
+	if ! [ -f "${DNSMASQ_IPSET_HOSTS}" ] ; then
+		error "Не найден файл настроек ${DNSMASQ_IPSET_HOSTS}"
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi
@@ -288,7 +293,7 @@ cmd_debug_dnsmasq() {
 		return
 	fi
 	if ! [ -f "${DNSMASQ_DEMON}" ] ; then
-		error "Не найден файл запуска DNSMasq ${DNSMASQ_DEMON}"
+		error "Не найден файл запуска ${DNSMASQ_DEMON}"
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -424,10 +424,10 @@ cmd_ipset() {
 			output='Не используются IP или диапазоны в kvas list.'
 		fi
 
-		echo_debug 'IP 0' "${output}"
+		echo_debug 'Для IP 0' "${output}"
 	else
 		output=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | head -n 15 | cut -d' ' -f1)
-		echo_debug "IP ${count}, произвольные 15:" "${output}"
+		echo_debug "Для IP ${count}, произвольные 15:" "${output}"
 	fi
 }
 

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -419,7 +419,7 @@ cmd_ipset() {
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -eq 0 ]; then
-		echo_debug 'Для доменов 0' 'Или нет корректных доменов в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
+		output='Или нет корректных доменов в kvas list;\nили ни одного DNS-запроса о доменах из списка ещё не приходило;\nили проблема с перехватом DNS, вызовите kvas debug dns.'
 	else
 		# геморрой из-за неподдержки -k в sort
 		output=''
@@ -428,22 +428,25 @@ cmd_ipset() {
 		done
 		output=${output:0:-1}
 
-		echo_debug "Для доменов ${count}, последние:" "${output}"
+		cached=', последние:'
 	fi
+	echo_debug "Для доменов ${count}${cached}" "${output}"
 
 	count=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | wc -l)
 	if [ "$count" -eq 0 ]; then
 		if grep -Eq -- "${IP_FILTER}" "${KVAS_LIST_FILE}"; then
-			output='Или нет корректных IP или диапазонов в kvas list;\nили проблема с их переносом, вызовите kvas ipset clear.'
+			output='Или нет корректных IP, диапазонов в kvas list;\nили проблема с их переносом, вызовите kvas ipset clear.'
 		else
 			output='Не используются IP или диапазоны в kvas list.'
 		fi
 
-		echo_debug 'Для IP 0' "${output}"
+		cached=''
 	else
 		output=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | head -n 15 | cut -d' ' -f1)
-		echo_debug "Для IP ${count}, произвольные 15:" "${output}"
+
+		cached=', произвольные 15:'
 	fi
+	echo_debug "Для IP ${count}${cached}" "${output}"
 }
 
 # ------------------------------------------------------------------------------------------

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -308,6 +308,7 @@ cmd_debug_dnsmasq() {
 		return
 	fi
 
+
 	if grep -q '^filter-rr=HTTPS' "${DNSMASQ_CONFIG}" ; then
 		local output='Отключен'
 	else
@@ -316,11 +317,11 @@ cmd_debug_dnsmasq() {
 	ready 'DNS ECH' && when_ok "${output}"
 
 	local cached=$(dnsmasq -v)
-
 	ready 'DNSMasq версия' && when_ok "$(echo "${cached}" | grep -Eo 'version [0-9\.]+' | head -n 1 | cut -d ' ' -f2)"
+	#echo_debug 'DNSMasq модули:' "$(echo "${cached}" | grep -F 'options:' | head -n 1 | cut -d ':' -f2 | xargs | grep -o '[^ ]*')"
+
 	echo_debug 'DNSMasq слушает:' "$(netstat -tulpn | grep -F 'dnsmasq')"
 
-	#echo_debug 'DNSMasq модули:' "$(echo "${cached}" | grep -F 'options:' | head -n 1 | cut -d ':' -f2 | xargs | grep -o '[^ ]*')"
 
 	ready 'Сайтов для сбора IP' && when_ok "$(grep /${IPSET_TABLE_NAME} ${DNSMASQ_IPSET_HOSTS} | wc -l)"
 
@@ -339,6 +340,7 @@ cmd_debug_dnsmasq() {
 	ready 'ifconfig.me' && when_ok "${output}"
 
 	echo_debug 'Часть конфига:' "$(head -n 6 ${DNSMASQ_IPSET_HOSTS})"
+
 
 	cached=$(grep 'server=' "${DNSMASQ_CONFIG}"      | head -1 | cut -d '=' -f2)
 	ready 'DNS запросы передаются' && when_ok "${cached}"

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -419,7 +419,17 @@ cmd_ipset() {
 	local cached=$(ipset list "${IPSET_TABLE_NAME}" | grep -vF 'timeout 0' | grep -vF ':')
 	local count=$(echo -n "${cached}" | wc -l)
 	if [ "$count" -eq 0 ]; then
-		output='Или не приходило ещё ни одного DNS-запроса о доменах из kvas list;\nили ошибки в конфигурации DNS, вызовите kvas debug dns;\nили проблема с перехватом DNS, вызовите kvas debug iptables.'
+		output='Или не приходило ещё ни одного DNS-запроса о доменах из kvas list;\nили ошибки в конфигурации DNS'
+		if [ -z "${1}" ] ; then
+			# если вызывается как один из дебагов, то можно передать silent/short
+			output="${output}, вызовите kvas debug dns"
+		fi
+		output="${output}"';\nили проблема с перехватом DNS'
+		if [ -z "${1}" ] ; then
+			# если вызывается как один из дебагов, то можно передать silent/short
+			output="${output}, вызовите kvas debug iptables"
+		fi
+		output="${output}."
 	else
 		# геморрой из-за неподдержки -k в sort
 		output=''
@@ -435,7 +445,12 @@ cmd_ipset() {
 	count=$(ipset list "${IPSET_TABLE_NAME}" | grep -F 'timeout 0' | wc -l)
 	if [ "$count" -eq 0 ]; then
 		if grep -Eq -- "${IP_FILTER}" "${KVAS_LIST_FILE}"; then
-			output='Или нет корректных IP, диапазонов в kvas list;\nили проблема с их переносом, вызовите kvas ipset clear.'
+			output='Или нет корректных IP, диапазонов в kvas list;\nили проблема с их переносом'
+			if [ -z "${1}" ] ; then
+				# если вызывается как один из дебагов, то можно передать silent/short
+				output="${output}, вызовите kvas ipset clear"
+			fi
+			output="${output}."
 		else
 			output='Не используются IP или диапазоны в kvas list.'
 		fi

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -244,9 +244,15 @@ cmd_debug_iptables() {
 	else
 		output=$(iptables__get_by_chain "${CHAIN_MARK_TO_TABLE}")
 	fi
+	if [ -z "${output}" ] ; then
+		output='Правила не найдены!\nСообщите об этом https://t.me/kvas_pro и вызовите kvas reset'
+	fi
 	echo_debug 'Роутинг подсетей' "${output}"
 
 	output=$(iptables__get_by_chain "${CHAIN_DNS}")
+	if [ -z "${output}" ] ; then
+		output='Правила не найдены!\nСообщите об этом https://t.me/kvas_pro и вызовите kvas reset'
+	fi
 	echo_debug 'Роутинг DNS' "${output}"
 
 	output=$(iptables -L PREROUTING -t mangle)

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -275,7 +275,8 @@ cmd_debug_iptables() {
 cmd_debug_dns() {
 	# если вызывается как один из дебагов, то можно передать silent/short
 	if [ -z "${1}" ] ; then
-		echo 'Для проверки перехватов DNS вызовите kvas debug iptables'
+		echo 'Перехваты DNS можно проверить командой kvas debug iptables'
+		echo 'Список IP для тоннеля можно посмотреть командой kvas ipset'
 		echo
 	fi
 
@@ -323,12 +324,6 @@ cmd_debug_dns() {
 	ready 'ifconfig.me' && when_ok "${output}"
 
 	echo_debug 'Часть конфига:' "$(head -n 6 ${DNSMASQ_IPSET_HOSTS})"
-
-	# если вызывается как один из дебагов, то можно передать silent
-	if [ -z "${1}" ] ; then
-		echo 'Для просмотра списка IP для тоннеля вызовите kvas ipset'
-		echo
-	fi
 
 	cached=$(grep 'server=' "${DNSMASQ_CONFIG}"      | head -1 | cut -d '=' -f2)
 	ready 'DNS запросы передаются' && when_ok "${cached}"

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -292,6 +292,11 @@ cmd_debug_dnsmasq() {
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi
+	if ! dnsmasq --test 2>&1 | grep -Fq 'check OK' ; then
+		error "Ошибки в файлах конфигурации ${DNSMASQ_CONFIG} или ${DNSMASQ_IPSET_HOSTS}"
+		echo 'Дальнейшая проверка остановлена.'
+		return
+	fi
 	if ! [ -f "${DNSMASQ_DEMON}" ] ; then
 		error "Не найден файл запуска ${DNSMASQ_DEMON}"
 		echo 'Дальнейшая проверка остановлена.'

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -276,34 +276,29 @@ cmd_debug_adguard() {
 	echo 'Полная поддержка AdGuardHome будет доделана в скором времени.'
 }
 
-cmd_debug_dnsmasq() {
+dnsmasq__is_working() {
 	if ! [ -f "${DNSMASQ_CONFIG}" ] ; then
 		error "Не найден файл настроек ${DNSMASQ_CONFIG}"
-		echo 'Дальнейшая проверка остановлена.'
-		return
-	fi
-	if ! [ -f "${DNSMASQ_IPSET_HOSTS}" ] ; then
+	elif ! [ -f "${DNSMASQ_IPSET_HOSTS}" ] ; then
 		error "Не найден файл настроек ${DNSMASQ_IPSET_HOSTS}"
-		echo 'Дальнейшая проверка остановлена.'
-		return
-	fi
-	if ! command -v dnsmasq 2>&1 >/dev/null ; then
+	elif ! command -v dnsmasq 2>&1 >/dev/null ; then
 		error 'Не найдена команда dnsmasq'
-		echo 'Дальнейшая проверка остановлена.'
-		return
-	fi
-	if ! dnsmasq --test 2>&1 | grep -Fq 'check OK' ; then
+	elif ! dnsmasq --test 2>&1 | grep -Fq 'check OK' ; then
 		error "Ошибки в файлах конфигурации ${DNSMASQ_CONFIG} или ${DNSMASQ_IPSET_HOSTS}"
-		echo 'Дальнейшая проверка остановлена.'
-		return
-	fi
-	if ! [ -f "${DNSMASQ_DEMON}" ] ; then
+	elif ! [ -f "${DNSMASQ_DEMON}" ] ; then
 		error "Не найден файл запуска ${DNSMASQ_DEMON}"
-		echo 'Дальнейшая проверка остановлена.'
+	elif ! "${DNSMASQ_DEMON}" status | grep -Fq 'alive' ; then
+		error 'Не запущен DNSMasq'
+	else
+		true
 		return
 	fi
-	if ! "${DNSMASQ_DEMON}" status | grep -Fq 'alive' ; then
-		error 'Не запущен DNSMasq'
+
+	false
+}
+
+cmd_debug_dnsmasq() {
+	if ! dnsmasq__is_working ; then
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi

--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -278,7 +278,12 @@ cmd_debug_adguard() {
 
 cmd_debug_dnsmasq() {
 	if ! [ -f "${DNSMASQ_CONFIG}" ]; then
-		echo "Не найдена конфигурация DNSMasq ${DNSMASQ_CONFIG}"
+		error "Не найдена конфигурация DNSMasq ${DNSMASQ_CONFIG}"
+		echo 'Дальнейшая проверка остановлена.'
+		return
+	fi
+	if ! command -v dnsmasq 2>&1 >/dev/null ; then
+		error 'Не найдена команда dnsmasq'
 		echo 'Дальнейшая проверка остановлена.'
 		return
 	fi

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -62,6 +62,7 @@ ADBLOCK_SOURCES_LIST_BACKUP=${KVAS_BACKUP_PATH}/sources.list
 ADGUARDHOME_LOG=/opt/var/log/AdGuardHome.log
 ADGUARDHOME_DEMON=/opt/etc/init.d/S99adguardhome
 DNSMASQ_DEMON=/opt/etc/init.d/S56dnsmasq
+DNSCRYPT_DEMON=/opt/etc/init.d/S09dnscrypt-proxy2
 HOME_PATH=/opt/apps/kvas
 
 

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -370,23 +370,13 @@ is_ip_private() {
 }
 
 get_external_interface() {
-	local interfaces=$( /opt/sbin/ip a )
-
-	for interface in eth3 eth2.4 eth2.2 ppp0 ppp1 ; do
-		local interface_address=$( echo "$interfaces" | grep "global ${interface}" | tr -s ' ' | cut -d ' ' -f 3 )
-		if [ -z "${interface_address}" ]; then
-			continue
-		fi
-		if is_ip_private $interface_address; then
-			continue
-		fi
-
-		# в этом интерфейсе есть global и нет private IP
-		# в идеале можно ещё проверить, что это вообще IP или диапазон
+	local interface=$( ip route | grep -F 'default' | head -n 1 | grep -oE -- 'dev +[a-zA-Z0-9\+\.\-]+' | cut -d' ' -f2 )
+	if [ -n "${interface}" ] ; then
 		echo "${interface}"
 		return
-	done
+	fi
 
+	log_error 'Внешний сетевой интерфейс найти не удалось'
 	false
 }
 

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -93,6 +93,10 @@ get_regexp_ip_or_range() {
 	echo "^(${IP_FILTER}|${IP_FILTER}-${IP_FILTER}|${IP_FILTER}/[0-9]{1,2})$"
 }
 
+get_regexp_ip_with_or_without_port() {
+	echo "^(${IP_FILTER}|${IP_PORT_FILTER})$"
+}
+
 ERROR_LOG_FILE=/opt/tmp/kvas.err.log
 APP_NAME_DESC=КВАС
 

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1245,6 +1245,13 @@ cmd_dnsmasq_dns_change() {
 		if [ -z "${dns_new}" ]; then
 			dns_show
 		else
+			if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then
+				error "Параметр ${dns_new} не известен."
+				echo 'Можете передать любой IP с портом или без.'
+
+				exit 2
+			fi
+
 			dnsmasq_dns_change "${dns_new}" "${cmd}"
 		fi
 	}

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1250,15 +1250,15 @@ cmd_dnsmasq_dns_change() {
 		return
 	fi
 
-		if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then
-			error "Параметр ${dns_new} не известен."
-			echo 'Можете передать любой IP с портом или без.'
+	if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then
+		error "Параметр ${dns_new} не известен."
+		echo 'Можете передать любой IP с портом или без.'
 
-			return 2
-		fi
+		return 2
+	fi
 
-		cmd=${2:-restart}
-		dnsmasq_dns_change "${dns_new}" "${cmd}"
+	cmd=${2:-restart}
+	dnsmasq_dns_change "${dns_new}" "${cmd}"
 }
 
 # ------------------------------------------------------------------------------------------

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1239,13 +1239,14 @@ dnsmasq_dns_change() {
 #
 # ------------------------------------------------------------------------------------------
 cmd_dnsmasq_dns_change() {
-	exit_when_adguard_on status; 
+	exit_when_adguard_on status
 	if [ "${status}" != 0 ] ; then
 		return 1
 	fi
 
-	dns_new=${1}; cmd=${2:-restart}
-	if [ -z "${dns_new}" ]; then
+	dns_new=${1}
+	cmd=${2:-restart}
+	if [ -z "${dns_new}" ] ; then
 		dns_show
 	else
 		if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1245,10 +1245,11 @@ cmd_dnsmasq_dns_change() {
 	fi
 
 	dns_new=${1}
-	cmd=${2:-restart}
 	if [ -z "${dns_new}" ] ; then
 		dns_show
-	else
+		return
+	fi
+
 		if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then
 			error "Параметр ${dns_new} не известен."
 			echo 'Можете передать любой IP с портом или без.'
@@ -1256,8 +1257,8 @@ cmd_dnsmasq_dns_change() {
 			return 2
 		fi
 
+		cmd=${2:-restart}
 		dnsmasq_dns_change "${dns_new}" "${cmd}"
-	fi
 }
 
 # ------------------------------------------------------------------------------------------

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1244,19 +1244,19 @@ cmd_dnsmasq_dns_change() {
 		return 1
 	fi
 
-		dns_new=${1}; cmd=${2:-restart}
-		if [ -z "${dns_new}" ]; then
-			dns_show
-		else
-			if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then
-				error "Параметр ${dns_new} не известен."
-				echo 'Можете передать любой IP с портом или без.'
+	dns_new=${1}; cmd=${2:-restart}
+	if [ -z "${dns_new}" ]; then
+		dns_show
+	else
+		if ! echo "${dns_new}" | grep -qE "$(get_regexp_ip_with_or_without_port)" ; then
+			error "Параметр ${dns_new} не известен."
+			echo 'Можете передать любой IP с портом или без.'
 
-				return 2
-			fi
-
-			dnsmasq_dns_change "${dns_new}" "${cmd}"
+			return 2
 		fi
+
+		dnsmasq_dns_change "${dns_new}" "${cmd}"
+	fi
 }
 
 # ------------------------------------------------------------------------------------------

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -1240,7 +1240,10 @@ dnsmasq_dns_change() {
 # ------------------------------------------------------------------------------------------
 cmd_dnsmasq_dns_change() {
 	exit_when_adguard_on status; 
-	[ "${status}" = 0 ] && {
+	if [ "${status}" != 0 ] ; then
+		return 1
+	fi
+
 		dns_new=${1}; cmd=${2:-restart}
 		if [ -z "${dns_new}" ]; then
 			dns_show
@@ -1249,12 +1252,11 @@ cmd_dnsmasq_dns_change() {
 				error "Параметр ${dns_new} не известен."
 				echo 'Можете передать любой IP с портом или без.'
 
-				exit 2
+				return 2
 			fi
 
 			dnsmasq_dns_change "${dns_new}" "${cmd}"
 		fi
-	}
 }
 
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Кажущийся бесконечным процесс, начатый в #215:
1. Если каких-то данных не было, то их вывод пропускался. Сейчас же выводится и табличка (иначе было легко пропустить); и разъяснения, небольшие инструкции пользователям (которые можно будет скрыть при использовании этой функции в большом дебаге). Во всех трёх функциях.
2. Набралось 3 человека, сломавших себе интернет вызовом `kvas dns debug`. С одной стороны, сами перепутали последовательность параметров, не скопировали. С другой — ну понятно же, что имелось ввиду.
2.1. Команда `kvas dns` теперь проверяет, что передан IP с портом или без.
2.2. `kvas dns debug` и `kvas debug dns` делают сейчас одно и тоже.
3. Более адекватный код для определения внешнего интерфейса.
4. Пользователям AdGuardHome сообщение, что их доделки будут в скором времени (в конце беты 10 нужно будет создать под это дело задачу).
5. Через `kvas ipset 8.8.8.8` можно проверить вхождение конкретного IP.
6. 11 проверок DNSMasq и DNSCrypt; подсказывающие, что с ними что-то не так (избавило бы от кучи обращений).
7. Выводится аналогичная остальным DNS-серверам информация о встроенном в Кинетик NDNProxy (позволит узнать, например, слушает ли он 53 порт).