### PR TITLE
Сети: в списке системные

### DIFF
--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -2075,7 +2075,7 @@ show_vpn_list() {
 	num=0;
 
 	while read -r line || [ -n "${line}" ]; do
-		cli_inface_desc=$(echo "${line}" | cut -d"|" -f3)
+		cli_inface_desc=$(echo "${line}" | cut -d"|" -f3 | xargs)
 		if [ -z "${cli_inface_desc}" ]; then
 			continue
 		fi

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -2075,10 +2075,13 @@ show_vpn_list() {
 	num=0;
 
 	while read -r line || [ -n "${line}" ]; do
+		cli_inface_desc=$(echo "${line}" | cut -d"|" -f3)
+		if [ -z "${cli_inface_desc}" ]; then
+			continue
+		fi
 
 		num=$((num + 1))
 		is_current_vpn=$(echo "${line}" | grep -i "${inface_entware}")
-		cli_inface_desc=$(echo "${line}" | cut -d"|" -f3)
 		cli_inface=$(echo "${line}" | cut -d"|" -f1)
 		ent_inface=$(echo "${line}" | cut -d"|" -f2)
 		net_ip=$(get_ip_by_inface "${ent_inface}")


### PR DESCRIPTION
Ловил в одном из 10–20 случаев, когда при выборе интерфейса в том числе системные. Выбрать нужный всё равно было можно (просто он становился каким-нибудь 15ым), поэтому относился низкоприоритетно.

Предполагаю, что проблема в 
```
/opt/etc/ndm/ifcreated.d/kvas-iface-add
/opt/etc/ndm/ifdestroyed.d/kvas-iface-del
```
Они входят в вопрос #220 и упомянуты третьим пунктом в #236

Чтобы сейчас не пугать пользователей, просто скрыл последствия (а не победил причину).