### PR TITLE
Сети: в списке системные

### DIFF
--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -2078,7 +2078,7 @@ show_vpn_list() {
 
 		num=$((num + 1))
 		is_current_vpn=$(echo "${line}" | grep -i "${inface_entware}")
-		cli_inface_desc=$(echo "${line}" | cut -d"|" -f3)
+		cli_inface_desc=$(echo "${line}" | cut -d'|' -f3 | xargs)
 		cli_inface=$(echo "${line}" | cut -d"|" -f1)
 		ent_inface=$(echo "${line}" | cut -d"|" -f2)
 		net_ip=$(get_ip_by_inface "${ent_inface}")

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -2075,10 +2075,13 @@ show_vpn_list() {
 	num=0;
 
 	while read -r line || [ -n "${line}" ]; do
-
 		num=$((num + 1))
+
 		is_current_vpn=$(echo "${line}" | grep -i "${inface_entware}")
 		cli_inface_desc=$(echo "${line}" | cut -d'|' -f3 | xargs)
+		if [ -z "${cli_inface_desc}" ]; then
+			cli_inface_desc='системный, для устранения вызовите kvas vpn rescan'
+		fi
 		cli_inface=$(echo "${line}" | cut -d"|" -f1)
 		ent_inface=$(echo "${line}" | cut -d"|" -f2)
 		net_ip=$(get_ip_by_inface "${ent_inface}")

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -2070,6 +2070,9 @@ is_vpn_interface_connected() {
 #
 # ------------------------------------------------------------------------------------------
 show_vpn_list() {
+	# Удаляем интерфейсы без человеческого имени
+	sed -i '/|$/d;/|""$/d' "${INFACE_NAMES_FILE}"
+
 # set -xeu
 	inface_entware=$(get_current_vpn_interface 'entware')
 	num=0;

--- a/opt/bin/libs/vpn
+++ b/opt/bin/libs/vpn
@@ -2083,7 +2083,7 @@ show_vpn_list() {
 		ent_inface=$(echo "${line}" | cut -d"|" -f2)
 		net_ip=$(get_ip_by_inface "${ent_inface}")
 		[ -n "${net_ip}" ] && net_ip=" [${net_ip}]"
-		mess="${num}. Интерфейс ${cli_inface_desc}${net_ip}"
+		mess="${num}. ${cli_inface_desc}${net_ip}"
 		sleep 1
 		connected=$(is_vpn_interface_connected "${cli_inface}")
 


### PR DESCRIPTION
Ловил в одном из 10–20 случаев, когда при выборе интерфейса в том числе системные. Выбрать нужный всё равно было можно (просто он становился каким-нибудь 15ым), поэтому относился низкоприоритетно.

Предполагаю, что проблема на стыке основного сканирования и триггеров
```
/opt/etc/ndm/ifcreated.d/kvas-iface-add
/opt/etc/ndm/ifdestroyed.d/kvas-iface-del
```
Они входят в вопрос #220 и упомянуты третьим пунктом в #236, так что не занимался заранее.

Чтобы сейчас не пугать пользователей, просто скрыл последствия (а не победил причину).