### PR TITLE
Исключения петель доработки

### DIFF
--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -679,6 +679,7 @@ function vpn__get_tunnel_addresses() {
 	# формат L2TP
 	address=$(echo "${api_response}" | jq -r '.peer')
 	if [ -n "${address}" ]; then
+		log_warning "Адрес подключения L2TP ${address}"
 		echo "${address}"
 		return
 	fi
@@ -686,6 +687,7 @@ function vpn__get_tunnel_addresses() {
 	# формат IKEv2
 	address=$(echo "${api_response}" | jq -r '.tunnel.destination')
 	if [ -n "${address}" ]; then
+		log_warning "Адрес подключения IKEv2 ${address}"
 		echo "${address}"
 		return
 	fi
@@ -702,6 +704,7 @@ function vpn__get_tunnel_addresses() {
 		addresses="${addresses}$(echo "${address}" | cut -d':' -f1)"$'\n'
 	done
 	if [ -n "${addresses}" ]; then
+		log_warning "Адреса подключения Wireguard $(echo "${addresses}" | xargs)"
 		echo "${addresses}"
 		return
 	fi
@@ -724,6 +727,7 @@ function vpn__get_tunnel_addresses() {
 		addresses="${addresses}${address}"$'\n'
 	done
 	if [ -n "${addresses}" ]; then
+		log_warning "IP неизвестного VPN-подключения $(echo "${addresses}" | xargs)"
 		echo "${addresses}"
 		return
 	fi
@@ -743,6 +747,7 @@ get_tunnel_addresses() {
 }
 
 get_tunnel_ip() {
+	local ips=
 	for address in $( get_tunnel_addresses ) ; do
 		if [ -z "${address}" ] ; then
 			continue
@@ -753,13 +758,16 @@ get_tunnel_ip() {
 			continue
 		fi
 
+		ips=''
 		for ip in $( dns__get_ips_by_domain "${address}" ) ; do
 			if [ -z "${ip}" ] ; then
 				continue
 			fi
-
 			echo "${ip}"
+
+			ips="${ips} ${ip}"
 		done
+		log_warning "IP для домена ${address}: ${ips}"
 	done
 }
 

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -661,7 +661,7 @@ get_external_ip() {
 	/opt/sbin/ip route get ${dns} | sed -E 's/.*src (\S+) .*/\1/;t;d'
 }
 
-function vpn__get_tunnel_addresses() {
+vpn__get_tunnel_addresses() {
 	if [ -z "${1}" ] ; then
 		error "[${FUNCNAME}] Не задан обязательный аргумент — название соединения"
 		return

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -677,15 +677,15 @@ function vpn__get_tunnel_addresses() {
 	local address
 
 	# формат L2TP
-	address=$(echo "${api_response}" | jq -r '.peer' | grep -oE "${IP_FILTER}")
-	if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
+	address=$(echo "${api_response}" | jq -r '.peer')
+	if [ -n "${address}" ]; then
 		echo "${address}"
 		return
 	fi
 
 	# формат IKEv2
-	address=$(echo "${api_response}" | jq -r '.tunnel.destination' | grep -oE "${IP_FILTER}")
-	if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
+	address=$(echo "${api_response}" | jq -r '.tunnel.destination')
+	if [ -n "${address}" ]; then
 		echo "${address}"
 		return
 	fi
@@ -694,11 +694,8 @@ function vpn__get_tunnel_addresses() {
 
 	# формат Wireguard
 	addresses=''
-	for address in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address' | grep -oE "${IP_FILTER}") ; do
-		if [ -z "${address}" ] ; then
-			continue
-		fi
-		if is_ip_private "${address}" ; then
+	for address in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address') ; do
+		if [ -z "${address}" ]; then
 			continue
 		fi
 
@@ -735,16 +732,37 @@ function vpn__get_tunnel_addresses() {
 	echo ''
 }
 
-get_tunnel_ip() {
+get_tunnel_addresses() {
 	if is_shadowsocks_enabled ; then
-		local addresses=$(get_from_json "${SHADOWSOCKS_CONF}" 'server')
+		echo $(get_from_json "${SHADOWSOCKS_CONF}" 'server')
 	elif is_vless_enabled ; then
-		local addresses=$(get_from_json "${VLESS_CONFIG_FILE}" 'address' 'outbounds')
+		echo $(get_from_json "${VLESS_CONFIG_FILE}" 'address' 'outbounds')
 	else
-		local addresses=$(vpn__get_tunnel_addresses "$(get_config_value INFACE_CLI)")
+		echo $(vpn__get_tunnel_ip "$(get_config_value INFACE_CLI)")
 	fi
+}
 
-	echo "${addresses}"
+get_tunnel_ip() {
+	local without_port
+	for address in $( get_tunnel_addresses ) ; do
+		if [ -z "${address}" ] ; then
+			continue
+		fi
+		without_port=$(echo "${address}" | cut -d':' -f1)
+
+		if echo "${without_port}" | grep -qE "^${IP_FILTER}$" ; then
+			echo "${without_port}"
+			continue
+		fi
+
+		for ip in $( dns__get_ips_by_domain "${without_port}" ) ; do
+			if [ -z "${ip}" ] ; then
+				continue
+			fi
+
+			echo "${ip}"
+		done
+	done
 }
 
 # ------------------------------------------------------------------------------------------

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -699,7 +699,7 @@ function vpn__get_tunnel_addresses() {
 			continue
 		fi
 
-		addresses="${addresses}${address}"$'\n'
+		addresses="${addresses}$(echo "${address}" | cut -d':' -f1)"$'\n'
 	done
 	if [ -n "${addresses}" ]; then
 		echo "${addresses}"
@@ -743,19 +743,17 @@ get_tunnel_addresses() {
 }
 
 get_tunnel_ip() {
-	local without_port
 	for address in $( get_tunnel_addresses ) ; do
 		if [ -z "${address}" ] ; then
 			continue
 		fi
-		without_port=$(echo "${address}" | cut -d':' -f1)
 
-		if echo "${without_port}" | grep -qE "^${IP_FILTER}$" ; then
-			echo "${without_port}"
+		if echo "${address}" | grep -qE "^${IP_FILTER}$" ; then
+			echo "${address}"
 			continue
 		fi
 
-		for ip in $( dns__get_ips_by_domain "${without_port}" ) ; do
+		for ip in $( dns__get_ips_by_domain "${address}" ) ; do
 			if [ -z "${ip}" ] ; then
 				continue
 			fi

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -695,9 +695,14 @@ function vpn__get_tunnel_addresses() {
 	# формат Wireguard
 	addresses=''
 	for address in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address' | grep -oE "${IP_FILTER}") ; do
-		if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
-			addresses="${addresses}${address}"$'\n'
+		if [ -z "${address}" ] ; then
+			continue
 		fi
+		if is_ip_private "${address}" ; then
+			continue
+		fi
+
+		addresses="${addresses}${address}"$'\n'
 	done
 	if [ -n "${addresses}" ]; then
 		echo "${addresses}"
@@ -708,9 +713,14 @@ function vpn__get_tunnel_addresses() {
 	#ToDo: проверить на всех типах VPN! Для каждого добавить json-блок выше и исключение сюда мусорных массивов.
 	addresses=''
 	for address in $(echo "${api_response}" | sed '/allow-ips/,/]/d' | grep -oE "${IP_FILTER}") ; do
-		if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
-			addresses="${addresses}${address}"$'\n'
+		if [ -z "${address}" ] ; then
+			continue
 		fi
+		if is_ip_private "${address}" ; then
+			continue
+		fi
+
+		addresses="${addresses}${address}"$'\n'
 	done
 	if [ -n "${addresses}" ]; then
 		echo "${addresses}"

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -742,7 +742,7 @@ get_tunnel_addresses() {
 	elif is_vless_enabled ; then
 		echo $(get_from_json "${VLESS_CONFIG_FILE}" 'address' 'outbounds')
 	else
-		echo $(vpn__get_tunnel_ip "$(get_config_value INFACE_CLI)")
+		echo $(vpn__get_tunnel_addresses "$(get_config_value INFACE_CLI)")
 	fi
 }
 

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -399,7 +399,7 @@ get_external_interface() {
 
 get_entware_ikev2_inface() {
 	if ! is_os_below_4_2 ; then
-		# на последних прошивках IKEv2 на этом интерфейсе, но у всех ли?
+		# на последних прошивках IKEv2 на этом интерфейсе
 		echo 'xfrms+'
 		return
 	fi
@@ -661,7 +661,7 @@ get_external_ip() {
 	/opt/sbin/ip route get ${dns} | sed -E 's/.*src (\S+) .*/\1/;t;d'
 }
 
-function vpn__get_tunnel_ip() {
+function vpn__get_tunnel_addresses() {
 	if [ -z "${1}" ] ; then
 		error "[${FUNCNAME}] Не задан обязательный аргумент — название соединения"
 		return
@@ -674,44 +674,46 @@ function vpn__get_tunnel_ip() {
 		return
 	fi
 
+	local address
+
 	# формат L2TP
-	local ip=$(echo "${api_response}" | jq -r '.peer' | grep -oE "${IP_FILTER}")
-	if [ -n "${ip}" ] && ! is_ip_private "${ip}" ; then
-		echo "${ip}"
+	address=$(echo "${api_response}" | jq -r '.peer' | grep -oE "${IP_FILTER}")
+	if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
+		echo "${address}"
 		return
 	fi
 
 	# формат IKEv2
-	ip=$(echo "${api_response}" | jq -r '.tunnel.destination' | grep -oE "${IP_FILTER}")
-	if [ -n "${ip}" ] && ! is_ip_private "${ip}" ; then
-		echo "${ip}"
+	address=$(echo "${api_response}" | jq -r '.tunnel.destination' | grep -oE "${IP_FILTER}")
+	if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
+		echo "${address}"
 		return
 	fi
 
-	local ips
+	local addresses
 
 	# формат Wireguard
-	ips=''
-	for ip in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address' | grep -oE "${IP_FILTER}") ; do
-		if [ -n "${ip}" ] && ! is_ip_private "${ip}" ; then
-			ips="${ips}${ip}"$'\n'
+	addresses=''
+	for address in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address' | grep -oE "${IP_FILTER}") ; do
+		if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
+			addresses="${addresses}${address}"$'\n'
 		fi
 	done
-	if [ -n "${ips}" ]; then
-		echo "${ips}"
+	if [ -n "${addresses}" ]; then
+		echo "${addresses}"
 		return
 	fi
 
 	# универсальный код по поиску внешнего IP вне allow-ips
 	#ToDo: проверить на всех типах VPN! Для каждого добавить json-блок выше и исключение сюда мусорных массивов.
-	ips=''
-	for ip in $(echo "${api_response}" | sed '/allow-ips/,/]/d' | grep -oE "${IP_FILTER}") ; do
-		if [ -n "${ip}" ] && ! is_ip_private "${ip}" ; then
-			ips="${ips}${ip}"$'\n'
+	addresses=''
+	for address in $(echo "${api_response}" | sed '/allow-ips/,/]/d' | grep -oE "${IP_FILTER}") ; do
+		if [ -n "${address}" ] && ! is_ip_private "${address}" ; then
+			addresses="${addresses}${address}"$'\n'
 		fi
 	done
-	if [ -n "${ips}" ]; then
-		echo "${ips}"
+	if [ -n "${addresses}" ]; then
+		echo "${addresses}"
 		return
 	fi
 
@@ -721,12 +723,13 @@ function vpn__get_tunnel_ip() {
 
 get_tunnel_ip() {
 	if is_shadowsocks_enabled ; then
-		echo $(get_from_json "${SHADOWSOCKS_CONF}" 'server')
+		local addresses=$(get_from_json "${SHADOWSOCKS_CONF}" 'server')
 	elif is_vless_enabled ; then
-		echo $(get_from_json "${VLESS_CONFIG_FILE}" 'address' 'outbounds')
+		local addresses=$(get_from_json "${VLESS_CONFIG_FILE}" 'address' 'outbounds')
 	else
-		echo $(vpn__get_tunnel_ip "$(get_config_value INFACE_CLI)")
+		local addresses=$(vpn__get_tunnel_addresses "$(get_config_value INFACE_CLI)")
 	fi
+	echo "${addresses}"
 }
 
 # ------------------------------------------------------------------------------------------

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -681,6 +681,13 @@ function vpn__get_tunnel_ip() {
 		return
 	fi
 
+	# формат IKEv2
+	ip=$(echo "${api_response}" | jq -r '.tunnel.destination' | grep -oE "${IP_FILTER}")
+	if [ -n "${ip}" ] && ! is_ip_private "${ip}" ; then
+		echo "${ip}"
+		return
+	fi
+
 	local ips
 
 	# формат Wireguard

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -719,6 +719,10 @@ function vpn__get_tunnel_addresses() {
 		if is_ip_private "${address}" ; then
 			continue
 		fi
+		# часто встречается, не является тоннелем
+		if [ "${address}" = '8.8.8.8' ] ; then
+			continue
+		fi
 
 		addresses="${addresses}${address}"$'\n'
 	done
@@ -739,6 +743,7 @@ get_tunnel_ip() {
 	else
 		local addresses=$(vpn__get_tunnel_addresses "$(get_config_value INFACE_CLI)")
 	fi
+
 	echo "${addresses}"
 }
 

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -677,7 +677,7 @@ vpn__get_tunnel_addresses() {
 	local address
 
 	# формат L2TP
-	address=$(echo "${api_response}" | jq -r '.peer')
+	address=$(echo "${api_response}" | jq -r '.peer // empty')
 	if [ -n "${address}" ]; then
 		log_warning "Адрес подключения L2TP ${address}"
 		echo "${address}"
@@ -685,7 +685,7 @@ vpn__get_tunnel_addresses() {
 	fi
 
 	# формат IKEv2
-	address=$(echo "${api_response}" | jq -r '.tunnel.destination')
+	address=$(echo "${api_response}" | jq -r '.tunnel.destination // empty')
 	if [ -n "${address}" ]; then
 		log_warning "Адрес подключения IKEv2 ${address}"
 		echo "${address}"
@@ -696,7 +696,7 @@ vpn__get_tunnel_addresses() {
 
 	# формат Wireguard
 	addresses=''
-	for address in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address') ; do
+	for address in $(echo "${api_response}" | jq -r '.wireguard.peer[]? .endpoint.address // empty') ; do
 		if [ -z "${address}" ]; then
 			continue
 		fi

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -267,16 +267,6 @@ ip4__ipset__fill_destination_excluded() {
 	# Служебный IP Keenetic, например для my.keenetic.net
 	ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" '78.47.125.180'
 
-	# Был случай, когда ресурс из списка совпадал с IP роутера
-	# Это приводило к не рабочему DDNS и прочим проблемам
-	ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" "$(get_external_ip)"
-
-	# Исключаем (loopback) адреса тоннеля из попадания в тоннель
-	# Случай тоже детектирован и чуть более разрушителен
-	for ip in $(get_tunnel_ip) ; do
-		ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" "${ip}"
-	done
-
 	while read -r ip_or_range || [ -n "${ip_or_range}" ]; do
 		# пропускаем строки с комментариями
 		[ "${ip_or_range:0:1}" = '#' ] && continue
@@ -286,6 +276,16 @@ ip4__ipset__fill_destination_excluded() {
 
 		ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" "${ip_or_range}"
 	done < "${FILE_RESERVED}"
+
+	# Был случай, когда ресурс из списка совпадал с IP роутера
+	# Это приводило к не рабочему DDNS и прочим проблемам
+	ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" "$(get_external_ip)"
+
+	# Исключаем (loopback) адреса тоннеля из попадания в тоннель
+	# Случай тоже детектирован и чуть более разрушителен
+	for ip in $(get_tunnel_ip) ; do
+		ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" "${ip}"
+	done
 }
 
 ip4__ipset__destroy() {


### PR DESCRIPTION
1. Добавлен случай основного IKEv2.
2. Логируется, откуда получаем адрес тоннеля.
3. Забыто, что адрес тоннеля может быть доменом. В этом случае прогоняем его через DNS и исключаем полученные IP. Логируем и это.