### PR TITLE
[10+] VPN при отключенных ускорениях

### DIFF
--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -528,17 +528,17 @@ ip4__mark__create_chain() {
 		ip4__route__add_table
 		ip4__rule__add_mark_to_table
 
-			# выходим, если не новое соединение
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
+		# выходим, если не новое соединение
+		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
 
-			# или маркируем соединение
-			#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
+		# или маркируем соединение
+		#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
 
-			# или переносим маркер, проверяем и возвращаем обратно
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
+		# или переносим маркер, проверяем и возвращаем обратно
+		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
+		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
+		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -96,15 +96,15 @@ guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 # проверка на доступность программного и аппаратного ускорения
 # ------------------------------------------------------------------------------------------
 fast_hw_enabled() {
-	is_os_4 && ask=enable || ask=false; 
-	! curl -s localhost:79/rci/show/rc/ppe | grep hardware -C1 | grep -q ${ask}
+	is_os_4 && ask='enable' || ask='false'
+	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'hardware' -C1 | grep -qF "${ask}"
 }
 fast_sw_enabled() {
-	is_os_4 && ask=enable || ask=false
-	! curl -s localhost:79/rci/show/rc/ppe | grep software -C1 | grep -q ${ask}
+	is_os_4 && ask='enable' || ask='false'
+	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'software' -C1 | grep -qF "${ask}"
 }
 fastnet_enabled()(fast_hw_enabled || fast_sw_enabled)
-fastnet_support()(curl -s localhost:79/rci/show/version | grep -q ppe)
+fastnet_support()(curl -s '127.0.0.1:79/rci/show/version' | grep -qF 'ppe')
 
 # ------------------------------------------------------------------------------------------
 #

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -529,13 +529,15 @@ ip4__mark__create_chain() {
 		ip4__rule__add_mark_to_table
 
 		if fastnet_enabled ; then
+			# выходим, если не новое соединение
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
+
 			# маркер из соединения в пакет
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
 			# выходим, если уже помечен
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-
 			# новое соединение
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
 			# маркер пакета в соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
 		else

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -96,11 +96,21 @@ guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 # проверка на доступность программного и аппаратного ускорения
 # ------------------------------------------------------------------------------------------
 fast_hw_enabled() {
-	is_os_4 && ask='enable' || ask='false'
+	if is_os_4; then
+		local ask='enable'
+	else
+		local ask='false'
+	fi
+
 	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'hardware' -C1 | grep -qF "${ask}"
 }
 fast_sw_enabled() {
-	is_os_4 && ask='enable' || ask='false'
+	if is_os_4; then
+		local ask='enable'
+	else
+		local ask='false'
+	fi
+
 	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'software' -C1 | grep -qF "${ask}"
 }
 fastnet_enabled()(fast_hw_enabled || fast_sw_enabled)

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -95,11 +95,10 @@ guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 # ------------------------------------------------------------------------------------------
 # проверка на доступность программного и аппаратного ускорения
 # ------------------------------------------------------------------------------------------
-fastnet_support()(curl -s localhost:79/rci/show/version | grep -q ppe)
 fast_hw_enabled()(is_os_4 && ask=enable || ask=false; ! curl -s localhost:79/rci/show/rc/ppe | grep hardware -C1 | grep -q ${ask})
 fast_sw_enabled()(is_os_4 && ask=enable || ask=false; ! curl -s localhost:79/rci/show/rc/ppe | grep software -C1 | grep -q ${ask})
 fastnet_enabled()(fast_hw_enabled || fast_sw_enabled)
-
+fastnet_support()(curl -s localhost:79/rci/show/version | grep -q ppe)
 
 # ------------------------------------------------------------------------------------------
 #
@@ -503,18 +502,20 @@ ip4__mark__create_chain() {
 		ip4__route__add_table
 		ip4__rule__add_mark_to_table
 
-		#ToDo: fastnet_enabled -j MARK --set-mark ${MARK_NUM}
 		if fastnet_enabled ; then
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
-			# возможно лишняя проверка
+
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			# Правила по SYN (начало нового соединения) в save не наблюдается. Нужно ли?
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
 		else
-			# возможно лишняя проверка
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j MARK --set-mark ${MARK_NUM}
+			#/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
 		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
 }

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -96,7 +96,12 @@ guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 # проверка на доступность программного и аппаратного ускорения
 # ------------------------------------------------------------------------------------------
 fast_hw_enabled() {
-	if is_os_4; then
+	if ! is_os_below_4_2 ; then
+		# no: yes
+		# "no": true,
+		local ask='no'
+	elif is_os_4; then
+		# "enabled": false,
 		local ask='enable'
 	else
 		local ask='false'
@@ -105,7 +110,12 @@ fast_hw_enabled() {
 	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'hardware' -C1 | grep -qF "${ask}"
 }
 fast_sw_enabled() {
-	if is_os_4; then
+	if ! is_os_below_4_2 ; then
+		# no: yes
+		# "no": true,
+		local ask='no'
+	elif is_os_4; then
+		# "enabled": false,
 		local ask='enable'
 	else
 		local ask='false'

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -534,8 +534,6 @@ ip4__mark__create_chain() {
 			# выходим, если уже помечен
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 
-			# TCP SYN (новое TCP соединение)
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
 			# новое соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
 			# маркер пакета в соединение

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -530,21 +530,21 @@ ip4__mark__create_chain() {
 
 		if fastnet_enabled ; then
 			# маркер из соединения в пакет
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
 			# выходим, если уже помечен
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 
 			# TCP SYN (новое TCP соединение)
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
 			# новое соединение
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
 			# маркер пакета в соединение
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
 		else
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j MARK --set-mark ${MARK_NUM}
-			#/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
+			#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
 		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
 }

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -542,7 +542,7 @@ ip4__mark__create_chain() {
 		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
 		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
-	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
+	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN"
 }
 
 
@@ -597,7 +597,7 @@ ip4__shadowsocks__add_routing_for_home() {
 
 # когда ускорение подключено
 ip4__mark__add_routing_for_home() {
-	ip4__add_routing_for_home "${TABLE_MARK}" "${CHAIN_MARK}" 'VPN со включенным ускорением'
+	ip4__add_routing_for_home "${TABLE_MARK}" "${CHAIN_MARK}" 'VPN'
 }
 
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -276,6 +276,7 @@ ip4__ipset__fill_destination_excluded() {
 
 	# Исключаем (loopback) адреса тоннеля из попадания в тоннель
 	# Случай тоже детектирован и чуть более разрушителен
+	IFS=$'\n'
 	for tunnel_ip in $(get_tunnel_ip) ; do
 		/opt/sbin/ipset -exist add "${IPSET_DESTINATION_EXCLUDED}" "${tunnel_ip}"
 	done
@@ -353,6 +354,7 @@ ip4__chain__exclude_source_by_config() {
 	fi
 	local regexp_ip_or_range=$(get_regexp_ip_or_range)
 
+	IFS=' '
 	for ip_or_range in ${values//+/ } ; do
 		# защита от дурака; не обязательна, если проверять входящие данные
 		if ! echo "${ip_or_range}" | grep -qE -- "${regexp_ip_or_range}" ; then
@@ -394,6 +396,7 @@ ip4__chain__create_for_data() {
 
 	# если цепочка данных будет подключена выше DNS, то она может 
 	# перехватить направленный вовне трафик
+	IFS=' '
 	for protocol in udp tcp ; do
 		/opt/sbin/iptables -A "${chain_name}" -w -t "${table}" -p "${protocol}" --dport 53 -j RETURN
 	done
@@ -472,6 +475,7 @@ ip4__proxy__create_chain() {
 
 		ip4__chain__create_for_data "${table}" "${chain_name}"
 
+		IFS=' '
 		for protocol in udp tcp ; do
 			# не будет ли задвоения без -w?
 			/opt/sbin/iptables -A "${chain_name}" -t "${table}" -p "${protocol}" -j REDIRECT --to-port "${port}"
@@ -602,6 +606,7 @@ ip4__dns__create_chain() {
 
 	ip4__chain__exclude_source_by_config "${TABLE_DNS}" "${CHAIN_DNS}"
 
+	IFS=' '
 	for protocol in udp tcp ; do
 		# не будет ли задвоения без -w?
 		/opt/sbin/iptables -A "${CHAIN_DNS}" -t "${TABLE_DNS}" -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
@@ -885,6 +890,7 @@ ip4__delete_routing_by_list_for_net() {
 
 # Для команды route by_list net add — роутинг по списку для сетей
 ip4__add_routing_by_list_for_net_from_config() {
+	IFS=' '
 	for net_interface in $(get_guest_inface_list_from_config) ; do
 		ip4__add_routing_by_list_for_net "${net_interface}"
 	done
@@ -898,6 +904,7 @@ ip4__add_routing_for_ip_from_config() {
 
 	local values=$(get_config_value 'route_full_ip')
 	if [ -n "${values}" ] ; then
+		IFS=' '
 		for ip_or_range in ${values//+/ } ; do
 			# защита от дурака; не обязательна, если проверять входящие данные
 			if ! echo "${ip_or_range}" | grep -qE -- "${regexp_ip_or_range}" ; then
@@ -915,6 +922,7 @@ ip4__add_routing_for_ip_from_config() {
 
 	values=$(get_config_value 'route_by_list_ip')
 	if [ -n "${values}" ] ; then
+		IFS=' '
 		for ip_or_range in ${values//+/ } ; do
 			# защита от дурака; не обязательна, если проверять входящие данные
 			if ! echo "${ip_or_range}" | grep -qE -- "${regexp_ip_or_range}" ; then
@@ -982,6 +990,7 @@ ip4_firewall_set_all_rules() {
 
 # Для команды route by_list net del — роутинг по списку для сетей
 ip4__delete_routing_by_list_for_net_from_config() {
+	IFS=' '
 	for net_interface in $(get_guest_inface_list_from_config) ; do
 		ip4__delete_routing_by_list_for_net "${net_interface}"
 	done
@@ -995,6 +1004,7 @@ ip4__delete_routing_for_ip_from_config() {
 
 	local values=$(get_config_value 'route_full_ip')
 	if [ -n "${values}" ] ; then
+		IFS=' '
 		for ip_or_range in ${values//+/ } ; do
 			# защита от дурака; не обязательна, если проверять входящие данные
 			if ! echo "${ip_or_range}" | grep -qE -- "${regexp_ip_or_range}" ; then
@@ -1012,6 +1022,7 @@ ip4__delete_routing_for_ip_from_config() {
 
 	values=$(get_config_value 'route_by_list_ip')
 	if [ -n "${values}" ] ; then
+		IFS=' '
 		for ip_or_range in ${values//+/ } ; do
 			# защита от дурака; не обязательна, если проверять входящие данные
 			if ! echo "${ip_or_range}" | grep -qE -- "${regexp_ip_or_range}" ; then

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -95,8 +95,14 @@ guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 # ------------------------------------------------------------------------------------------
 # проверка на доступность программного и аппаратного ускорения
 # ------------------------------------------------------------------------------------------
-fast_hw_enabled()(is_os_4 && ask=enable || ask=false; ! curl -s localhost:79/rci/show/rc/ppe | grep hardware -C1 | grep -q ${ask})
-fast_sw_enabled()(is_os_4 && ask=enable || ask=false; ! curl -s localhost:79/rci/show/rc/ppe | grep software -C1 | grep -q ${ask})
+fast_hw_enabled() {
+	is_os_4 && ask=enable || ask=false; 
+	! curl -s localhost:79/rci/show/rc/ppe | grep hardware -C1 | grep -q ${ask}
+}
+fast_sw_enabled() {
+	is_os_4 && ask=enable || ask=false
+	! curl -s localhost:79/rci/show/rc/ppe | grep software -C1 | grep -q ${ask}
+}
 fastnet_enabled()(fast_hw_enabled || fast_sw_enabled)
 fastnet_support()(curl -s localhost:79/rci/show/version | grep -q ppe)
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -1090,6 +1090,7 @@ ip4__flush() {
 		local parts=" ${1} "
 	fi
 
+	# если не нужно точечно, то используем общий jump
 	if echo "${parts}" | grep -Fq ' net ' ; then
 		ip4__delete_routing_by_list_for_net_from_config
 	fi
@@ -1099,12 +1100,12 @@ ip4__flush() {
 		ip4__delete_routing_for_ip_from_config
 	fi
 
-	if echo "${parts}" | grep -Fq ' chain ' ; then
-		if echo "${parts}" | grep -Fq ' table ' ; then
-			ip4__rule__delete_mark_to_table
-			ip4__route__flush_table
-		fi
+	if echo "${parts}" | grep -Fq ' table ' ; then
+		ip4__rule__delete_mark_to_table
+		ip4__route__flush_table
+	fi
 
+	if echo "${parts}" | grep -Fq ' chain ' ; then
 		ip4__chain__delete_jump "${TABLE_DNS}" "${CHAIN_DNS}"
 		ip4__chain__delete      "${TABLE_DNS}" "${CHAIN_DNS}"
 
@@ -1115,6 +1116,7 @@ ip4__flush() {
 		ip4__chain__delete_jump "${TABLE_MARK}" "${CHAIN_MARK}"
 		ip4__chain__delete      "${TABLE_MARK}" "${CHAIN_MARK}"
 
+		# если привязана к какой-то исторической цепочке, может упасть
 		ip4__ipset__destroy_destination_excluded
 	elif echo "${parts}" | grep -Fq ' jump ' ; then
 		ip4__chain__delete_jump "${TABLE_DNS}"          "${CHAIN_DNS}"

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -532,13 +532,13 @@ ip4__mark__create_chain() {
 			# выходим, если не новое соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
 
-			# маркер из соединения в пакет
+			# или маркируем соединение
+			#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
+
+			# или переносим маркер, проверяем и возвращаем обратно
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
-			# выходим, если уже помечен
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-			# новое соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
-			# маркер пакета в соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
 		else
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -163,7 +163,7 @@ iptables__delete_rule() {
 		return
 	fi
 
-	iptables -t "${table}" -D $(echo "${rule:3}")
+	/opt/sbin/iptables -t "${table}" -D $(echo "${rule:3}")
 }
 
 # удаляет правила, получаемые по критерию
@@ -207,7 +207,7 @@ ip4__ipset__is_exist() {
 	fi
 	local ipset_name="${1}"
 
-	! ipset list "${ipset_name}" 2>&1 | grep -q 'name does not exist'
+	! /opt/sbin/ipset list "${ipset_name}" 2>&1 | grep -q 'name does not exist'
 }
 
 ip4__ipset__create() {
@@ -294,7 +294,7 @@ ip4__ipset__destroy() {
 
 	log_warning "Уничтожение набора IP ${ipset_name}"
 
-	#ipset flush "${ipset_name}"
+	#/opt/sbin/ipset flush "${ipset_name}"
 	/opt/sbin/ipset destroy "${ipset_name}" \
 	 || {
 		error "[${FUNCNAME}] Ошибка при уничтожении набора IP ${ipset_name}"
@@ -331,7 +331,7 @@ ip4__chain__is_exist() {
 	fi
 	local chain_name="${2}"
 
-	iptables-save -t "${table}" | grep -Fq "${chain_name}"
+	/opt/sbin/iptables-save -t "${table}" | grep -Fq "${chain_name}"
 }
 
 ip4__chain__exclude_source_by_config() {
@@ -361,7 +361,7 @@ ip4__chain__exclude_source_by_config() {
 
 		log_warning "Исключение ${ip_or_range} из ${chain_name}"
 
-		iptables -A "${chain_name}" -w -t "${table}" -s "${ip_or_range}" -j RETURN
+		/opt/sbin/iptables -A "${chain_name}" -w -t "${table}" -s "${ip_or_range}" -j RETURN
 	done
 }
 
@@ -385,17 +385,17 @@ ip4__chain__create_for_data() {
 
 	log_warning "Создание цепочки ${chain_name} в ${table} для перенаправления данных"
 
-	iptables -N "${chain_name}" -w -t "${table}"
+	/opt/sbin/iptables -N "${chain_name}" -w -t "${table}"
 
 	ip4__chain__exclude_source_by_config "${table}" "${chain_name}"
 
 	ip4__ipset__fill_destination_excluded
-	iptables -A "${chain_name}" -w -t "${table}" -m set --match-set "${IPSET_DESTINATION_EXCLUDED}" dst -j RETURN
+	/opt/sbin/iptables -A "${chain_name}" -w -t "${table}" -m set --match-set "${IPSET_DESTINATION_EXCLUDED}" dst -j RETURN
 
 	# если цепочка данных будет подключена выше DNS, то она может 
 	# перехватить направленный вовне трафик
 	for protocol in udp tcp ; do
-		iptables -A "${chain_name}" -w -t "${table}" -p "${protocol}" --dport 53 -j RETURN
+		/opt/sbin/iptables -A "${chain_name}" -w -t "${table}" -p "${protocol}" --dport 53 -j RETURN
 	done
 }
 
@@ -418,8 +418,8 @@ ip4__chain__delete() {
 
 	log_warning "Удаление цепочки ${chain_name} в ${table}"
 
-	iptables -F "${chain_name}" -t "${table}"
-	iptables -X "${chain_name}" -t "${table}"
+	/opt/sbin/iptables -F "${chain_name}" -t "${table}"
+	/opt/sbin/iptables -X "${chain_name}" -t "${table}"
 }
 
 # удаляем входы в цепочку
@@ -474,7 +474,7 @@ ip4__proxy__create_chain() {
 
 		for protocol in udp tcp ; do
 			# не будет ли задвоения без -w?
-			iptables -A "${chain_name}" -t "${table}" -p "${protocol}" -j REDIRECT --to-port "${port}"
+			/opt/sbin/iptables -A "${chain_name}" -t "${table}" -p "${protocol}" -j REDIRECT --to-port "${port}"
 		done
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки при установке правил трафика для прокси"
 }
@@ -505,11 +505,11 @@ ip4__vpn_fast__create_chain() {
 		ip4__route__add_table
 		ip4__rule__add_mark_to_table
 
-		iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
-		iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-		iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
-		iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
-		iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
+		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
+		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
+		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
 }
 
@@ -567,7 +567,7 @@ ip4__add_routing_for_home() {
 
 	log_warning "Подключение перенаправления трафика для домашней сети в тоннель ${3}"
 
-	iptables -A PREROUTING -w -t "${table}" -i "${net_interface}" -m set --match-set "${IPSET_TABLE_NAME}" dst -j "${chain_name}"
+	/opt/sbin/iptables -A PREROUTING -w -t "${table}" -i "${net_interface}" -m set --match-set "${IPSET_TABLE_NAME}" dst -j "${chain_name}"
 }
 
 ip4__shadowsocks__add_routing_for_home() {
@@ -592,19 +592,19 @@ ip4__vpn_fast__add_routing_for_home() {
 
 # Создаёт (если нет) цепочку для DNS редиректа
 ip4__dns__create_chain() {
-	if iptables-save | grep -Fq "${CHAIN_DNS}"; then
+	if /opt/sbin/iptables-save | grep -Fq "${CHAIN_DNS}"; then
 		return
 	fi
 
 	log_warning 'Создание цепочки для DNS перенаправления'
 
-	iptables -N "${CHAIN_DNS}" -w -t "${TABLE_DNS}"
+	/opt/sbin/iptables -N "${CHAIN_DNS}" -w -t "${TABLE_DNS}"
 
 	ip4__chain__exclude_source_by_config "${TABLE_DNS}" "${CHAIN_DNS}"
 
 	for protocol in udp tcp ; do
 		# не будет ли задвоения без -w?
-		iptables -A "${CHAIN_DNS}" -t "${TABLE_DNS}" -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
+		/opt/sbin/iptables -A "${CHAIN_DNS}" -t "${TABLE_DNS}" -p "${protocol}" --dport 53 -j DNAT --to-destination 127.0.0.1:"${DNS_PORT}"
 	done
 }
 
@@ -621,7 +621,7 @@ ip4__get_rulenum() {
 	local table='nat'
 	local chain='PREROUTING'
 
-	echo $(iptables-save -t "${table}" | grep -F "${chain}" | grep -vF :"${chain}" \
+	echo $(/opt/sbin/iptables-save -t "${table}" | grep -F "${chain}" | grep -vF :"${chain}" \
 	 | grep -nF -- "${find}" | head -n 1 | grep -oE '^[0-9]+')
 }
 
@@ -661,7 +661,7 @@ ip4__dns__add_routing() {
 		submessage=''
 	fi
 
-	if iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -Fq "${CHAIN_DNS}" ; then
+	if /opt/sbin/iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -Fq "${CHAIN_DNS}" ; then
 		return
 	fi
 	local rulenum
@@ -671,7 +671,7 @@ ip4__dns__add_routing() {
 
 	ip4__dns__create_chain
 	# без echo дублирование пробелов (что даёт warning и проблему наличия)
-	iptables -I PREROUTING "${rulenum}" -w -t "${TABLE_DNS}"$(echo "${iptables_filter}") -j "${CHAIN_DNS}"
+	/opt/sbin/iptables -I PREROUTING "${rulenum}" -w -t "${TABLE_DNS}"$(echo "${iptables_filter}") -j "${CHAIN_DNS}"
 }
 
 # Отключение перехвата dns-запросов в dnsmasq
@@ -696,7 +696,7 @@ ip4__dns__delete_routing() {
 	log_warning "Отключение DNS перенаправления${submessage}"
 
 	# без echo дублирование пробелов (что даёт warning и проблему наличия)
-	iptables -D PREROUTING -t "${TABLE_DNS}"$(echo "${iptables_filter}") -j "${CHAIN_DNS}"
+	/opt/sbin/iptables -D PREROUTING -t "${TABLE_DNS}"$(echo "${iptables_filter}") -j "${CHAIN_DNS}"
 }
 
 
@@ -753,13 +753,13 @@ ip4__add_routing() {
 		submessage=" ipset ${ipset_list} и${submessage}"
 	fi
 
-	if iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -Fq "${chain_name}" ; then
+	if /opt/sbin/iptables-save | grep -F 'PREROUTING' | grep -F -- "${iptables_filter}" | grep -Fq "${chain_name}" ; then
 		return
 	fi
 
 	log_warning "Подключение перехвата трафика по${submessage}"
 
-	iptables -A PREROUTING -w -t "${table}" $(echo "${iptables_filter}") -j "${chain_name}"
+	/opt/sbin/iptables -A PREROUTING -w -t "${table}" $(echo "${iptables_filter}") -j "${chain_name}"
 }
 
 ip4__add_routing_by_list_for_net() {
@@ -789,12 +789,12 @@ ip4__add_routing_by_list_for_net() {
 
 		# случай основного VPN и отключенного ускорения требует дополнительной проверки
 		# но именно таким код был изначально, т.е. он точно не "ухудшится"
-		if iptables-save | grep -F 'POSTROUTING' | grep -F "${net_pool}" | grep -F "${net_interface}" | grep -Fq 'MASQUERADE' ; then
+		if /opt/sbin/iptables-save | grep -F 'POSTROUTING' | grep -F "${net_pool}" | grep -F "${net_interface}" | grep -Fq 'MASQUERADE' ; then
 			return
 		fi
 		log_warning "Подключение правил гостевого трафика для VPN без ускорения по критерию ${iptables_filter}"
 
-		iptables -A POSTROUTING -w -t nat -s "${net_pool}" -o "${net_interface}" -j MASQUERADE
+		/opt/sbin/iptables -A POSTROUTING -w -t nat -s "${net_pool}" -o "${net_interface}" -j MASQUERADE
 	fi
 }
 
@@ -835,7 +835,7 @@ ip4__delete_routing() {
 
 	log_warning "Отключение перехвата трафика по${submessage}"
 
-	iptables -D PREROUTING -t "${table}" $(echo "${iptables_filter}") -j "${chain_name}"
+	/opt/sbin/iptables -D PREROUTING -t "${table}" $(echo "${iptables_filter}") -j "${chain_name}"
 }
 
 ip4__delete_routing_by_list_for_net() {
@@ -867,12 +867,12 @@ ip4__delete_routing_by_list_for_net() {
 
 		# случай основного VPN и отключенного ускорения требует дополнительной проверки
 		# но именно таким код был изначально, т.е. он точно не "ухудшится"
-		if ! iptables-save | grep -F 'POSTROUTING' | grep -F "${net_pool}" | grep -F "${net_interface}" | grep -Fq 'MASQUERADE' ; then
+		if ! /opt/sbin/iptables-save | grep -F 'POSTROUTING' | grep -F "${net_pool}" | grep -F "${net_interface}" | grep -Fq 'MASQUERADE' ; then
 			return
 		fi
 		log_warning "Отключение правил гостевого трафика для VPN без ускорения по критерию ${iptables_filter}"
 
-		iptables -D POSTROUTING -t nat -s "${net_pool}" -o "${net_interface}" -j MASQUERADE
+		/opt/sbin/iptables -D POSTROUTING -t nat -s "${net_pool}" -o "${net_interface}" -j MASQUERADE
 	fi
 }
 
@@ -1267,7 +1267,7 @@ ip4__rule__get_submessage() {
 
 ip4__rule__add_mark_to_table() {
 	local subrule="$(ip4__rule__get_sub)"
-	if ip rule show | grep -Fq "${subrule}" ; then
+	if /opt/sbin/ip rule show | grep -Fq "${subrule}" ; then
 		return
 	fi
 
@@ -1282,7 +1282,7 @@ ip4__rule__add_mark_to_table() {
 
 ip4__rule__delete_mark_to_table() {
 	local subrule="$(ip4__rule__get_sub)"
-	if ! ip rule show | grep -Fq "${subrule}" ; then
+	if ! /opt/sbin/ip rule show | grep -Fq "${subrule}" ; then
 		return
 	fi
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -528,7 +528,6 @@ ip4__mark__create_chain() {
 		ip4__route__add_table
 		ip4__rule__add_mark_to_table
 
-		if fastnet_enabled ; then
 			# выходим, если не новое соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
 
@@ -540,12 +539,6 @@ ip4__mark__create_chain() {
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
-		else
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
-			#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
-		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -92,10 +92,14 @@ inface_gw4()(get_gw4 "$(inface_ent)")
 inface_guest_gw4()(get_gw4 "${1}")
 guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 
+
 # ------------------------------------------------------------------------------------------
-# проверка на доступность программного и аппаратного ускорения
+#
+# Функции доступности программного и аппаратного ускорения
+#
 # ------------------------------------------------------------------------------------------
-fast_hw_enabled() {
+
+is_hwnat_enabled() {
 	if ! is_os_below_4_2 ; then
 		# no: yes
 		# "no": true,
@@ -109,7 +113,8 @@ fast_hw_enabled() {
 
 	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'hardware' -C1 | grep -qF "${ask}"
 }
-fast_sw_enabled() {
+
+is_swnat_enabled() {
 	if ! is_os_below_4_2 ; then
 		# no: yes
 		# "no": true,
@@ -123,8 +128,11 @@ fast_sw_enabled() {
 
 	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'software' -C1 | grep -qF "${ask}"
 }
-fastnet_enabled()(fast_hw_enabled || fast_sw_enabled)
-fastnet_support()(curl -s '127.0.0.1:79/rci/show/version' | grep -qF 'ppe')
+
+is_ppe_enabled()(is_hwnat_enabled || is_swnat_enabled)
+
+is_fastnet_supported()(curl -s '127.0.0.1:79/rci/show/version' | grep -qF 'ppe')
+
 
 # ------------------------------------------------------------------------------------------
 #

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -449,7 +449,7 @@ ip4__chain__delete_jump() {
 #
 # ------------------------------------------------------------------------------------------
 
-ip4__proxy__create_chain() {
+ip4__dnat_to_port__create_chain() {
 	if [ -z "${1}" ] ; then
 		error "[${FUNCNAME}] Не задан обязательный аргумент — таблица"
 		return
@@ -484,19 +484,13 @@ ip4__proxy__create_chain() {
 }
 
 ip4__shadowsocks__create_chain() {
+	#local local_port=$(get_from_json "${VLESS_CONFIG_FILE}" 'port' 'inbounds')
 	local local_port=$(get_config_value SSR_DNS_PORT)
 
-	ip4__proxy__create_chain "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" "${local_port}"
+	ip4__dnat_to_port__create_chain "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" "${local_port}"
 }
 
-ip4__vless__create_chain() {
-	local local_port=$(get_from_json "${VLESS_CONFIG_FILE}" 'port' 'inbounds')
-
-	ip4__proxy__create_chain "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" "${local_port}"
-}
-
-# когда ускорение подключено
-ip4__vpn_fast__create_chain() {
+ip4__mark__create_chain() {
 	{
 		if ip4__chain__is_exist "${TABLE_MARK}" "${CHAIN_MARK}" ; then
 			return
@@ -509,23 +503,18 @@ ip4__vpn_fast__create_chain() {
 		ip4__route__add_table
 		ip4__rule__add_mark_to_table
 
+		#ToDo: fastnet_enabled -j MARK --set-mark ${MARK_NUM}
+		if fastnet_enabled ; then
 		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
 		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
 		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
 		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
+		else
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j MARK --set-mark ${MARK_NUM}
+		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при включенном ускорении"
-}
-
-# когда программное и аппаратное ускорение отключено
-ip4__vpn_nofast__set_rules() {
-	{
-		#ToDo: должны работать таблицы или переписать на цепочки
-		log_warning 'Маркировка трафика для VPN при отключенном ускорении'
-
-		# правило не переписывалось, таким и было
-		ip4tables PREROUTING -t "${TABLE_MARK}" -i "$(inface_ent)" -m set --match-set ${IPSET_TABLE_NAME} dst -j MARK --set-mark ${MARK_NUM}
-	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN при отключенном ускорении"
 }
 
 
@@ -578,12 +567,8 @@ ip4__shadowsocks__add_routing_for_home() {
 	ip4__add_routing_for_home "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" 'ShadowSocks'
 }
 
-ip4__vless__add_routing_for_home() {
-	ip4__add_routing_for_home "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" 'VLESS'
-}
-
 # когда ускорение подключено
-ip4__vpn_fast__add_routing_for_home() {
+ip4__mark__add_routing_for_home() {
 	ip4__add_routing_for_home "${TABLE_MARK}" "${CHAIN_MARK}" 'VPN со включенным ускорением'
 }
 
@@ -777,29 +762,10 @@ ip4__add_routing_by_list_for_net() {
 	local iptables_filter
 	iptables_filter=$(iptables__get_subrule_for_net "${net_interface}")
 
-	if is_proxy_enabled ; then
+	if is_shadowsocks_enabled ; then
 		ip4__add_routing "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" "${iptables_filter}" "${IPSET_TABLE_NAME}"
-	elif fastnet_enabled ; then
-		ip4__add_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${iptables_filter}" "${IPSET_TABLE_NAME}"
 	else
-		ip4__dns__add_routing "${iptables_filter}"
-
-		# на выходе не доступен i
-		if [ "${net_interface}" = 'ikev2' ] ; then
-			local net_pool=$(get_ikev2_net_pool)
-		else
-			local net_pool=$(get_guest_net "${net_interface}")
-		fi
-		net_interface=$(get_external_interface)
-
-		# случай основного VPN и отключенного ускорения требует дополнительной проверки
-		# но именно таким код был изначально, т.е. он точно не "ухудшится"
-		if /opt/sbin/iptables-save | grep -F 'POSTROUTING' | grep -F "${net_pool}" | grep -F "${net_interface}" | grep -Fq 'MASQUERADE' ; then
-			return
-		fi
-		log_warning "Подключение правил гостевого трафика для VPN без ускорения по критерию ${iptables_filter}"
-
-		/opt/sbin/iptables -A POSTROUTING -w -t nat -s "${net_pool}" -o "${net_interface}" -j MASQUERADE
+		ip4__add_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${iptables_filter}" "${IPSET_TABLE_NAME}"
 	fi
 }
 
@@ -855,29 +821,10 @@ ip4__delete_routing_by_list_for_net() {
 
 	ip4__dns__delete_routing "${iptables_filter}"
 
-	if is_proxy_enabled ; then
+	if is_shadowsocks_enabled ; then
 		ip4__delete_routing "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" "${iptables_filter}" "${IPSET_TABLE_NAME}"
-	elif fastnet_enabled ; then
-		ip4__delete_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${iptables_filter}" "${IPSET_TABLE_NAME}"
 	else
-		ip4__dns__delete_routing "${iptables_filter}"
-
-		# на выходе не доступен i
-		if [ "${net_interface}" = 'ikev2' ] ; then
-			local net_pool=$(get_ikev2_net_pool)
-		else
-			local net_pool=$(get_guest_net "${net_interface}")
-		fi
-		net_interface=$(get_external_interface)
-
-		# случай основного VPN и отключенного ускорения требует дополнительной проверки
-		# но именно таким код был изначально, т.е. он точно не "ухудшится"
-		if ! /opt/sbin/iptables-save | grep -F 'POSTROUTING' | grep -F "${net_pool}" | grep -F "${net_interface}" | grep -Fq 'MASQUERADE' ; then
-			return
-		fi
-		log_warning "Отключение правил гостевого трафика для VPN без ускорения по критерию ${iptables_filter}"
-
-		/opt/sbin/iptables -D POSTROUTING -t nat -s "${net_pool}" -o "${net_interface}" -j MASQUERADE
+		ip4__delete_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${iptables_filter}" "${IPSET_TABLE_NAME}"
 	fi
 }
 
@@ -912,9 +859,9 @@ ip4__add_routing_for_ip_from_config() {
 			fi
 
 			ip_or_range=$(ip4__get_subrule_for_ip "${ip_or_range}")
-			if is_proxy_enabled ; then
+			if is_shadowsocks_enabled ; then
 				ip4__add_routing "${TABLE_DNAT_TO_PORT}"  "${CHAIN_DNAT_TO_PORT}"  "${ip_or_range}"
-			elif fastnet_enabled ; then
+			else
 				ip4__add_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${ip_or_range}"
 			fi
 		done
@@ -930,9 +877,9 @@ ip4__add_routing_for_ip_from_config() {
 			fi
 
 			ip_or_range=$(ip4__get_subrule_for_ip "${ip_or_range}")
-			if is_proxy_enabled ; then
+			if is_shadowsocks_enabled ; then
 				ip4__add_routing "${TABLE_DNAT_TO_PORT}"  "${CHAIN_DNAT_TO_PORT}"  "${ip_or_range}" "${IPSET_TABLE_NAME}"
-			elif fastnet_enabled ; then
+			else
 				ip4__add_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${ip_or_range}" "${IPSET_TABLE_NAME}"
 			fi
 		done
@@ -941,21 +888,14 @@ ip4__add_routing_for_ip_from_config() {
 
 ip4_mark_vpn_network() {
 	{
-		if fastnet_enabled ; then
-			ip4__vpn_fast__create_chain
-		else
-			ip4__vpn_nofast__set_rules
-		fi
+		ip4__mark__create_chain
 
 		# Сначала правила по IP, затем по сетям.
-		# Для отключенного ускорения первое не сделает ничего, пока 
-		# оно не будет переписано на цепочки
 		ip4__add_routing_for_ip_from_config
 		ip4__add_routing_by_list_for_net_from_config
-		if fastnet_enabled ; then
+
 			#ToDo: сделать home отключаемой
-			ip4__vpn_fast__add_routing_for_home
-		fi
+			ip4__mark__add_routing_for_home
 	} &>/dev/null
 }
 
@@ -965,17 +905,10 @@ ip4_firewall_set_all_rules() {
 
 		# Сначала правила по IP, затем по сетям
 		ip4__add_routing_for_ip_from_config &> /dev/null
+		ip4__add_routing_by_list_for_net_from_config &> /dev/null
+
 		#ToDo: сделать home отключаемой
 		ip4__shadowsocks__add_routing_for_home &> /dev/null
-		ip4__add_routing_by_list_for_net_from_config &> /dev/null
-	elif is_vless_enabled ; then
-		ip4__vless__create_chain &>/dev/null
-
-		# Сначала правила по IP, затем по сетям
-		ip4__add_routing_for_ip_from_config &> /dev/null
-		#ToDo: сделать home отключаемой
-		ip4__vless__add_routing_for_home &> /dev/null
-		ip4__add_routing_by_list_for_net_from_config &> /dev/null
 	else
 		ip4_mark_vpn_network
 	fi
@@ -1012,9 +945,9 @@ ip4__delete_routing_for_ip_from_config() {
 			fi
 
 			ip_or_range=$(ip4__get_subrule_for_ip "${ip_or_range}")
-			if is_proxy_enabled ; then
+			if is_shadowsocks_enabled ; then
 				ip4__delete_routing "${TABLE_DNAT_TO_PORT}"  "${CHAIN_DNAT_TO_PORT}"  "${ip_or_range}"
-			elif fastnet_enabled ; then
+			else
 				ip4__delete_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${ip_or_range}"
 			fi
 		done
@@ -1030,9 +963,9 @@ ip4__delete_routing_for_ip_from_config() {
 			fi
 
 			ip_or_range=$(ip4__get_subrule_for_ip "${ip_or_range}")
-			if is_proxy_enabled ; then
+			if is_shadowsocks_enabled ; then
 				ip4__delete_routing "${TABLE_DNAT_TO_PORT}"  "${CHAIN_DNAT_TO_PORT}"  "${ip_or_range}" "${IPSET_TABLE_NAME}"
-			elif fastnet_enabled ; then
+			else
 				ip4__delete_routing "${TABLE_MARK}" "${CHAIN_MARK}" "${ip_or_range}" "${IPSET_TABLE_NAME}"
 			fi
 		done
@@ -1047,7 +980,6 @@ ip4_firewall_flush_vpn_rules() {
 		# оно не будет переписано на цепочки
 		ip4__delete_routing_for_ip_from_config
 
-		if fastnet_enabled ; then
 			# достаточно удалять правила для br0, но на всякий случай
 			ip4__chain__delete_jump "${TABLE_MARK}" "${CHAIN_MARK}"
 			# в бета 9 перехваты DNS не очищались, да и они универсальны меж подключениями
@@ -1058,15 +990,11 @@ ip4_firewall_flush_vpn_rules() {
 			# По идее, нижеидущее нужно вызывать лишь при установке или удалении
 			#ip4__chain__delete "${TABLE_MARK}" "${CHAIN_MARK}"
 			#ip4__chain__delete "${TABLE_DNS}" "${CHAIN_DNS}"
-		else
-			# антиправила для ip4__vpn_nofast__set_rules
-			iptables__delete_rules "${TABLE_MARK}" "-j MARK --set-mark ${MARK_NUM}"
-		fi
 	} &>/dev/null
 }
 
 # для прокси подключений: ShadowSocks, VLESS
-ip4_firewall_flush_proxy() {
+ip4_firewall_flush_dnat_to_port() {
 	{
 		ip4__delete_routing_by_list_for_net_from_config
 		ip4__delete_routing_for_ip_from_config
@@ -1086,8 +1014,8 @@ ip4_firewall_flush_proxy() {
 
 # Удаляем все маршрутизирующие правила iptables
 ip4_firewall_flush_all_rules() {
-	if is_proxy_enabled ; then
-		ip4_firewall_flush_proxy
+	if is_shadowsocks_enabled ; then
+		ip4_firewall_flush_dnat_to_port
 	else
 		ip4_firewall_flush_vpn_rules
 	fi
@@ -1120,7 +1048,7 @@ ip4__flush() {
 		ip4__chain__delete_jump "${TABLE_DNS}" "${CHAIN_DNS}"
 		ip4__chain__delete      "${TABLE_DNS}" "${CHAIN_DNS}"
 
-		# можно оптимизировать, удаляя лишь нужный с проверкой is_proxy_enabled
+		# можно оптимизировать, удаляя лишь нужный с проверкой is_shadowsocks_enabled
 		# но тогда нужно переписать код в смене интерфейса
 		ip4__chain__delete_jump "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}"
 		ip4__chain__delete      "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}"
@@ -1132,7 +1060,7 @@ ip4__flush() {
 	elif echo "${parts}" | grep -Fq ' jump ' ; then
 		ip4__chain__delete_jump "${TABLE_DNS}"          "${CHAIN_DNS}"
 
-		# можно оптимизировать, удаляя лишь нужный с проверкой is_proxy_enabled
+		# можно оптимизировать, удаляя лишь нужный с проверкой is_shadowsocks_enabled
 		# но тогда нужно переписать код в смене интерфейса
 		ip4__chain__delete_jump "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}"
 		ip4__chain__delete_jump "${TABLE_MARK}"         "${CHAIN_MARK}"
@@ -1326,7 +1254,7 @@ ip4_rule_del_priority() {
 
 # Чистим и заполняем таблицу правил iptables для vpn подключений
 cmd_vpn_iptable_reset() {
-	if is_proxy_enabled ; then
+	if is_shadowsocks_enabled ; then
 		warning 'VPN соединение не активно!'
 	else
 		ready "Переустановка iptables для vpn завершена"

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -505,12 +505,14 @@ ip4__mark__create_chain() {
 
 		#ToDo: fastnet_enabled -j MARK --set-mark ${MARK_NUM}
 		if fastnet_enabled ; then
-		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
-		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
-		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
-		/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
+			# возможно лишняя проверка
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
 		else
+			# возможно лишняя проверка
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j MARK --set-mark ${MARK_NUM}
 		fi
@@ -894,8 +896,8 @@ ip4_mark_vpn_network() {
 		ip4__add_routing_for_ip_from_config
 		ip4__add_routing_by_list_for_net_from_config
 
-			#ToDo: сделать home отключаемой
-			ip4__mark__add_routing_for_home
+		#ToDo: сделать home отключаемой
+		ip4__mark__add_routing_for_home
 	} &>/dev/null
 }
 
@@ -980,16 +982,16 @@ ip4_firewall_flush_vpn_rules() {
 		# оно не будет переписано на цепочки
 		ip4__delete_routing_for_ip_from_config
 
-			# достаточно удалять правила для br0, но на всякий случай
-			ip4__chain__delete_jump "${TABLE_MARK}" "${CHAIN_MARK}"
-			# в бета 9 перехваты DNS не очищались, да и они универсальны меж подключениями
-			#ip4__chain__delete_jump "${TABLE_DNS}" "${CHAIN_DNS}"
+		# достаточно удалять правила для br0, но на всякий случай
+		ip4__chain__delete_jump "${TABLE_MARK}" "${CHAIN_MARK}"
+		# в бета 9 перехваты DNS не очищались, да и они универсальны меж подключениями
+		#ip4__chain__delete_jump "${TABLE_DNS}" "${CHAIN_DNS}"
 
-			# Во время работы удалять цепочки бессмысленно, они константны и не влияют ни на что
-			# Достаточно убрать входы туда, что сделано выше
-			# По идее, нижеидущее нужно вызывать лишь при установке или удалении
-			#ip4__chain__delete "${TABLE_MARK}" "${CHAIN_MARK}"
-			#ip4__chain__delete "${TABLE_DNS}" "${CHAIN_DNS}"
+		# Во время работы удалять цепочки бессмысленно, они константны и не влияют ни на что
+		# Достаточно убрать входы туда, что сделано выше
+		# По идее, нижеидущее нужно вызывать лишь при установке или удалении
+		#ip4__chain__delete "${TABLE_MARK}" "${CHAIN_MARK}"
+		#ip4__chain__delete "${TABLE_DNS}" "${CHAIN_DNS}"
 	} &>/dev/null
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -99,39 +99,34 @@ guest_net()(echo "$(inface_guest_gw4 "${1}" | cut -d'.' -f1-3).0/24")
 #
 # ------------------------------------------------------------------------------------------
 
-is_hwnat_enabled() {
+is_ppe_supported()(curl -s '127.0.0.1:79/rci/show/version' | grep -qF 'ppe')
+
+is_ppe_enabled() {
+	#ToDo: научить и WHNAT
+	if [ -z "${1}" ] ; then
+		is_ppe_enabled 'hardware' || is_ppe_enabled 'software'
+		return
+	fi
+	local engine="${1}"
+	if [ "${engine}" != 'hardware' ] && [ "${engine}" != 'software' ] ; then
+		error "[${FUNCNAME}] Передан неизвестный тип ускорителя ${engine}"
+		return
+	fi
+
+	local param
 	if ! is_os_below_4_2 ; then
 		# no: yes
 		# "no": true,
-		local ask='no'
+		param='no'
 	elif is_os_4; then
 		# "enabled": false,
-		local ask='enable'
+		param='enable'
 	else
-		local ask='false'
+		param='false'
 	fi
 
-	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'hardware' -C1 | grep -qF "${ask}"
+	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F "${engine}" -C1 | grep -qF "${param}"
 }
-
-is_swnat_enabled() {
-	if ! is_os_below_4_2 ; then
-		# no: yes
-		# "no": true,
-		local ask='no'
-	elif is_os_4; then
-		# "enabled": false,
-		local ask='enable'
-	else
-		local ask='false'
-	fi
-
-	! curl -s '127.0.0.1:79/rci/show/rc/ppe' | grep -F 'software' -C1 | grep -qF "${ask}"
-}
-
-is_ppe_enabled()(is_hwnat_enabled || is_swnat_enabled)
-
-is_fastnet_supported()(curl -s '127.0.0.1:79/rci/show/version' | grep -qF 'ppe')
 
 
 # ------------------------------------------------------------------------------------------

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -207,7 +207,7 @@ ip4__ipset__is_exist() {
 	fi
 	local ipset_name="${1}"
 
-	! /opt/sbin/ipset list "${ipset_name}" 2>&1 | grep -q 'name does not exist'
+	/opt/sbin/ipset -n list | grep -q "^${ipset_name}$"
 }
 
 ip4__ipset__create() {

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -529,13 +529,16 @@ ip4__mark__create_chain() {
 		ip4__rule__add_mark_to_table
 
 		if fastnet_enabled ; then
+			# маркер из соединения в пакет
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --restore-mark
-
+			# выходим, если уже помечен
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-			# Правила по SYN (начало нового соединения) в save не наблюдается. Нужно ли?
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
-			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
 
+			# TCP SYN (новое TCP соединение)
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" --syn -j MARK --set-mark ${MARK_NUM}
+			# новое соединение
+			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+			# маркер пакета в соединение
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -j CONNMARK --save-mark
 		else
 			/opt/sbin/iptables -A "${CHAIN_MARK}" -w -t "${TABLE_MARK}" -m mark --mark ${MARK_NUM} -j RETURN


### PR DESCRIPTION
1. Keenetic [в очередной раз изменили](https://forum.keenetic.ru/topic/17900-%D0%BA%D0%B0%D0%BA-%D0%BE%D0%BF%D1%80%D0%B5%D0%B4%D0%B5%D0%BB%D0%B8%D1%82%D1%8C-%D1%82%D0%B8%D0%BF-%D1%83%D1%81%D0%BA%D0%BE%D1%80%D0%B5%D0%BD%D0%B8%D1%8F-%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D1%83%D0%B5%D0%BC%D1%8B%D0%B9-%D1%80%D0%BE%D1%83%D1%82%D0%B5%D1%80%D0%BE%D0%BC-%D0%B2-keeneticos-41/) отдачу API, теперь для детекции надо смотреть `no: yes` и `"no": true`, функции определения не работали.
2. Это последняя область, не перетащенная на цепочки. Теперь обладает всеми фишками остальных случаев. Плюс выкинута куча устаревшего "специального" кода, т.к. отличается лишь создание цепочки.
3. Раз залез в создание цепочки, то пересмотрел ещё код включенного.
  3.1. Уже есть `-m conntrack --ctstate NEW`, не понятен смысл `--syn` (тоже новое соединение, но лишь для TCP). Убрал.
  3.2. Проверка нового соединения (раз осталась одна) перенесена выше, теперь пакеты после установления соединения не проходят процедуру переноса маркера из соединения в пакет и обратно (пакеты новых ходят по-старому). Должно уменьшить количество операций, немного ускорить.
  3.3. Альтернативный код по быстрой маркировке соединения тоже оставлен в комментах.
  3.4. После того, как правила включенного ускорения стали очень оптимизированными; отдельные облегчённые правила для отключенного потеряли смысл. Да и ничего отличительного больше не используется. Отключил оба ускорения через `no ppe` (галочки в настройках недостаточно, а у новых моделей ускорителей и вовсе 3), всё действительно работает!
4. _Это правильнее было бы отдельной веткой, но из-за текущего flow и сосредоточия на одном файле добавлено сюда._ Продолжена подправка моего кода: local, полные пути до команд, разделитель цикла. Проверка наличия IPSet.