### PR TITLE
[10+fixes] VLESS: подстройка цепочки и антипетель

### DIFF
--- a/opt/bin/libs/debug
+++ b/opt/bin/libs/debug
@@ -270,7 +270,7 @@ cmd_debug_iptables() {
 	output=$(ip route)
 	echo_debug 'Маршруты (подключитесь к гостевой заранее)' "${output}"
 
-	if is_proxy_enabled ; then
+	if is_shadowsocks_enabled ; then
 		title='Перенаправление в порт'
 		output="${CHAIN_DNAT_TO_PORT}"
 	else

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -615,21 +615,16 @@ nets__get() {
 	echo "${find_interface}" | sed -n "s/${param_field}|${param_field}|${param_field}|${param_field}/${param_replace}/p"
 }
 
-# любой из видов proxy: хоть ShadowSocks, хоть VLESS
-is_proxy_enabled() {
-	[ -f '/opt/etc/ndm/netfilter.d/100-proxy-redirect' ]
-}
-
 #ToDo: перейти везде на новые обёртки
 has_ssr_enable() {
-	is_proxy_enabled
+	is_shadowsocks_enabled
 }
 
 is_shadowsocks_enabled() {
 	[ "$(get_config_value INFACE_CLI)" = 'shadowsocks' ]
 }
 
-is_vless_enabled() {
+is_vless_over_proxy_enabled() {
 	[ "$(get_config_value INFACE_ENT)" = "${PROXY_VLESS_NAME}" ]
 }
 
@@ -884,7 +879,7 @@ vpn__get_tunnel_addresses() {
 get_tunnel_addresses() {
 	if is_shadowsocks_enabled ; then
 		echo $(get_from_json "${SHADOWSOCKS_CONF}" 'server')
-	elif is_vless_enabled ; then
+	elif is_vless_over_proxy_enabled ; then
 		echo $(get_from_json "${VLESS_CONFIG_FILE}" 'address' 'outbounds')
 	else
 		echo $(vpn__get_tunnel_addresses "$(get_config_value INFACE_CLI)")

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -625,7 +625,7 @@ is_shadowsocks_enabled() {
 }
 
 is_vless_over_proxy_enabled() {
-	[ "$(get_config_value INFACE_ENT)" = "${PROXY_VLESS_NAME}" ]
+	[ "$(get_config_value INFACE_CLI)" = "${PROXY_VLESS_NAME}" ]
 }
 
 

--- a/opt/bin/libs/main
+++ b/opt/bin/libs/main
@@ -621,11 +621,15 @@ has_ssr_enable() {
 }
 
 is_shadowsocks_enabled() {
-	[ "$(get_config_value INFACE_CLI)" = 'shadowsocks' ]
+	local tunnel_keenetic_name
+	tunnel_keenetic_name=$(get_config_value 'INFACE_CLI')
+	[ "${tunnel_keenetic_name}" = 'shadowsocks' ]
 }
 
 is_vless_over_proxy_enabled() {
-	[ "$(get_config_value INFACE_CLI)" = "${PROXY_VLESS_NAME}" ]
+	local tunnel_keenetic_name
+	tunnel_keenetic_name=$(get_config_value 'INFACE_CLI')
+	[ "${tunnel_keenetic_name}" = "${PROXY_VLESS_NAME}" ]
 }
 
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -540,10 +540,13 @@ ip4__mark__create_chain() {
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
 		else
-		# выходим, если не новое соединение
-		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
-		# или маркируем соединение
-		#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
+			# Оптимизация: выходим сразу, если не новое соединение
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
+
+			# Возможно, правильно ещё проверять наличие через пакет (первые 2 правила выше)
+
+			# Остаётся ещё вопрос, какая пометка быстрее: через set или через save
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
 		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN"
 }

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -595,9 +595,9 @@ ip4__shadowsocks__add_routing_for_home() {
 	ip4__add_routing_for_home "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" 'ShadowSocks'
 }
 
-# когда ускорение подключено
+# VPN, VLESS
 ip4__mark__add_routing_for_home() {
-	ip4__add_routing_for_home "${TABLE_MARK}" "${CHAIN_MARK}" 'VPN'
+	ip4__add_routing_for_home "${TABLE_MARK}" "${CHAIN_MARK}" 'сетевого интерфейса'
 }
 
 
@@ -1004,8 +1004,6 @@ ip4__delete_routing_for_ip_from_config() {
 ip4_firewall_flush_vpn_rules() {
 	{
 		ip4__delete_routing_by_list_for_net_from_config
-		# Для отключенного ускорения не сделает ничего, пока 
-		# оно не будет переписано на цепочки
 		ip4__delete_routing_for_ip_from_config
 
 		# достаточно удалять правила для br0, но на всякий случай
@@ -1062,8 +1060,6 @@ ip4__flush() {
 		ip4__delete_routing_by_list_for_net_from_config
 	fi
 	if echo "${parts}" | grep -Fq ' ip ' ; then
-		# Для отключенного ускорения не сделает ничего, пока 
-		# оно не будет переписано на цепочки
 		ip4__delete_routing_for_ip_from_config
 	fi
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -512,8 +512,9 @@ ip4__dnat_to_port__create_chain() {
 }
 
 ip4__shadowsocks__create_chain() {
-	#local local_port=$(get_from_json "${VLESS_CONFIG_FILE}" 'port' 'inbounds')
-	local local_port=$(get_config_value SSR_DNS_PORT)
+	local local_port
+	local_port=$(get_config_value SSR_DNS_PORT)
+	#local_port=$(get_from_json "${VLESS_CONFIG_FILE}" 'port' 'inbounds')
 
 	ip4__dnat_to_port__create_chain "${TABLE_DNAT_TO_PORT}" "${CHAIN_DNAT_TO_PORT}" "${local_port}"
 }

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -532,17 +532,19 @@ ip4__mark__create_chain() {
 		ip4__route__add_table
 		ip4__rule__add_mark_to_table
 
+		if is_vless_over_proxy_enabled ; then
+			# Теряет маркировку через раз, если не переносить для каждого пакета.
+			# Хотя домаркировки достаточно лишь для новых.
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack --ctstate NEW -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
+		else
 		# выходим, если не новое соединение
 		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
-
 		# или маркируем соединение
 		#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
-
-		# или переносим маркер, проверяем и возвращаем обратно
-		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
-		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
-		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
-		/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
+		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN"
 }
 

--- a/opt/etc/ndm/ndm
+++ b/opt/etc/ndm/ndm
@@ -543,10 +543,13 @@ ip4__mark__create_chain() {
 			# Оптимизация: выходим сразу, если не новое соединение
 			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m conntrack ! --ctstate NEW -j RETURN
 
-			# Возможно, правильно ещё проверять наличие через пакет (первые 2 правила выше)
-
-			# Остаётся ещё вопрос, какая пометка быстрее: через set или через save
-			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
+			# Нужно ли проверять наличие в новом соединении?
+			# Если нет, то можно схлопнуть до 2 правил
+			#/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --restore-mark
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -m mark --mark ${MARK_NUM} -j RETURN
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j MARK --set-mark ${MARK_NUM}
+			/opt/sbin/iptables -w -t "${TABLE_MARK}" -A "${CHAIN_MARK}" -j CONNMARK --save-mark
 		fi
 	} &>/dev/null || error "[${FUNCNAME}] Возникли ошибки во время маркировки трафика для VPN"
 }


### PR DESCRIPTION
1. Более корректная проверка, что ShadowSocks включен.
2. Антипетлевой механизм не работал для VLESS.
3. Изменение маркирующей цепочки.

>Оптимизация сетевых правил в случае VPN (нужен более широкий тест)

Указывал в _changelog_, что изменение достаточно сильное (мы перестаём вмешиваться в большинство пакетов); при такой фрагментированности и куче протоколов может что-то всплыть. Что и случилось — у троих VLESS начал пропускать половину пакетов, у двоих без изменений. При откате одной из оптимизаций VLESS возвращается в норму. Сейчас создание цепочки ветвится в зависимости от протокола (как ранее было для включенного и отключенного ускорения), для VPN более быстрый вариант.